### PR TITLE
Add rm and rmi commands

### DIFF
--- a/doc/meson.build
+++ b/doc/meson.build
@@ -9,6 +9,8 @@ manuals = [
   'toolbox-create.1',
   'toolbox-enter.1',
   'toolbox-list.1',
+  'toolbox-rm.1',
+  'toolbox-rmi.1',
 ]
 
 foreach manual: manuals

--- a/doc/toolbox-rm.1.md
+++ b/doc/toolbox-rm.1.md
@@ -1,0 +1,52 @@
+% toolbox-rm(1)
+
+## NAME
+toolbox\-rm - Remove one or more toolbox containers
+
+## SYNOPSIS
+**toolbox rm** [*--all*] [*--force*] [*CONTAINER*...]
+
+## DESCRIPTION
+
+Removes one or more toolbox containers from the host. The container should
+have been created using the `toolbox create` command.
+
+A toolbox container is an OCI container. Therefore, `toolbox rm` can be used
+interchangeably with `podman rm`.
+
+## OPTIONS ##
+
+The following options are understood:
+
+**--all, -a**
+
+Remove all toolbox containers. It can be used in conjuction with `--force` as
+well.
+
+**--force, -f**
+
+Force the removal of running and paused toolbox containers.
+
+## EXAMPLES
+
+### Remove a toolbox container named `fedora-toolbox-gegl:30`
+
+```
+$ toolbox rm fedora-toolbox-gegl:30
+```
+
+### Remove all toolbox containers, but not those that are running or paused
+
+```
+$ toolbox rm --all
+```
+
+### Remove all toolbox containers, including ones that are running or paused
+
+```
+$ toolbox rm --all --force
+```
+
+## SEE ALSO
+
+`buildah(1)`, `podman(1)`, `podman-rm(1)`

--- a/doc/toolbox-rmi.1.md
+++ b/doc/toolbox-rmi.1.md
@@ -1,0 +1,52 @@
+% toolbox-rmi(1)
+
+## NAME
+toolbox\-rmi - Remove one or more toolbox images
+
+## SYNOPSIS
+**toolbox rmi** [*--all*] [*--force*] [*IMAGE*...]
+
+## DESCRIPTION
+
+Removes one or more toolbox images from the host. The image should have been
+created using the `toolbox create` command.
+
+A toolbox image is an OCI image. Therefore, `toolbox rmi` can be used
+interchangeably with `podman rmi`.
+
+## OPTIONS ##
+
+The following options are understood:
+
+**--all, -a**
+
+Remove all toolbox images. It can be used in conjuction with `--force` as well.
+
+**--force, -f**
+
+Force the removal of toolbox images that are used by toolbox containers. The
+dependent containers will be removed as well.
+
+## EXAMPLES
+
+### Remove a toolbox image named `localhost/fedora-toolbox-gegl:30`
+
+```
+$ toolbox rmi localhost/fedora-toolbox-gegl:30
+```
+
+### Remove all toolbox images, but not those that are used by containers
+
+```
+$ toolbox rmi --all
+```
+
+### Remove all toolbox images and their dependent containers
+
+```
+$ toolbox rmi --all --force
+```
+
+## SEE ALSO
+
+`buildah(1)`, `podman(1)`, `podman-rm(1)`

--- a/doc/toolbox.1.md
+++ b/doc/toolbox.1.md
@@ -57,6 +57,14 @@ Enter an existing toolbox container for interactive use.
 
 List existing toolbox containers and images.
 
+**toolbox-rm(1)**
+
+Remove one or more toolbox containers.
+
+**toolbox-rmi(1)**
+
+Remove one or more toolbox images.
+
 ## SEE ALSO
 
 `buildah(1)`, `podman(1)`

--- a/toolbox
+++ b/toolbox
@@ -82,6 +82,26 @@ has_prefix()
 )
 
 
+has_substring()
+(
+    haystack="$1"
+    needle="$2"
+
+    ret_val=1
+
+    case "$haystack" in
+        *"$needle"* )
+            ret_val=0
+            ;;
+        * )
+            ret_val=1
+            ;;
+    esac
+
+    return $ret_val
+)
+
+
 is_integer()
 {
     [ "$1" != "" ] && [ $1 -eq $1 ] 2>&3
@@ -537,6 +557,137 @@ list_containers()
 )
 
 
+remove_containers()
+(
+    ids=$1
+    all=$2
+    force=$3
+
+    ret_val=0
+
+    $force && force_option="--force"
+
+    if $all; then
+        if ! ids=$($prefix_sudo podman ps \
+                           --all \
+                           --filter "label=com.redhat.component=fedora-toolbox" \
+                           --format "{{.ID}}" 2>&3); then
+            echo "$base_toolbox_command: failed to list containers" >&2
+            return 1
+        fi
+        if [ "$ids" != "" ]; then
+            ret_val=$(echo "$ids" \
+                      | (
+                            while read id; do
+                                if ! $prefix_sudo podman rm $force_option "$id" >/dev/null 2>&3; then
+                                    echo "$base_toolbox_command: failed to remove container $id" >&2
+                                    ret_val=1
+                                fi
+                            done
+
+                            echo "$ret_val"
+                        )
+                     )
+        fi
+    else
+        ret_val=$(echo "$ids" \
+                  | sed "s/ \+/\n/g" 2>&3 \
+                  | (
+                        while read -r id; do
+                            if ! labels=$($prefix_sudo podman inspect \
+                                                  --format "{{.Config.Labels}}" \
+                                                  --type container \
+                                                  "$id" 2>&3); then
+                                echo "$base_toolbox_command: failed to inspect $id" >&2
+                                ret_val=1
+                                continue
+                            fi
+                            if ! has_substring "$labels" "com.redhat.component:fedora-toolbox"; then
+                                echo "$base_toolbox_command: $id is not a toolbox container" >&2
+                                ret_val=1
+                                continue
+                            fi
+
+                            if ! $prefix_sudo podman rm $force_option "$id" >/dev/null 2>&3; then
+                                echo "$base_toolbox_command: failed to remove container $id" >&2
+                                ret_val=1
+                            fi
+                        done
+
+                        echo "$ret_val"
+                    )
+                 )
+    fi
+
+    return $ret_val
+)
+
+
+remove_images()
+(
+    ids=$1
+    all=$2
+    force=$3
+
+    ret_val=0
+
+    $force && force_option="--force"
+
+    if $all; then
+        if ! ids=$($prefix_sudo podman images \
+                           --filter "label=com.redhat.component=fedora-toolbox" \
+                           --format "{{.ID}}" 2>&3); then
+            echo "$0: failed to list images" >&2
+            return 1
+        fi
+        if [ "$ids" != "" ]; then
+            ret_val=$(echo "$ids" \
+                      | (
+                            while read id; do
+                                if ! $prefix_sudo podman rmi $force_option "$id" >/dev/null 2>&3; then
+                                    echo "$base_toolbox_command: failed to remove image $id" >&2
+                                    ret_val=1
+                                fi
+                            done
+
+                            echo "$ret_val"
+                        )
+                     )
+        fi
+    else
+        ret_val=$(echo "$ids" \
+                  | sed "s/ \+/\n/g" 2>&3 \
+                  | (
+                        while read -r id; do
+                            if ! labels=$($prefix_sudo podman inspect \
+                                                  --format "{{.Labels}}" \
+                                                  --type image \
+                                                  "$id" 2>&3); then
+                                echo "$base_toolbox_command: failed to inspect $id" >&2
+                                ret_val=1
+                                continue
+                            fi
+                            if ! has_substring "$labels" "com.redhat.component:fedora-toolbox"; then
+                                echo "$base_toolbox_command: $id is not a toolbox image" >&2
+                                ret_val=1
+                                continue
+                            fi
+
+                            if ! $prefix_sudo podman rmi $force_option "$id" >/dev/null 2>&3; then
+                                echo "$base_toolbox_command: failed to remove image $id" >&2
+                                ret_val=1
+                            fi
+                        done
+
+                        echo "$ret_val"
+                    )
+                 )
+    fi
+
+    return $ret_val
+)
+
+
 exit_if_extra_operand()
 {
     if [ "$1" != "" ]; then
@@ -615,6 +766,10 @@ usage()
     echo "   or: toolbox [-v | --verbose]"
     echo "               list [-c | --containers]"
     echo "                    [-i | --images]"
+    echo "   or: toolbox rm [-a | --all]"
+    echo "                  [-f | --force] [<container> ...]"
+    echo "   or: toolbox rmi [-a | --all]"
+    echo "   or:             [-f | --force] [<image> ...]"
     echo "   or: toolbox --help"
 }
 
@@ -790,6 +945,47 @@ case $op in
 
             $ls_images && [ "$images" != "" ] && echo "$images"
             $ls_containers && [ "$containers" != "" ] && echo "$containers"
+        fi
+        exit
+        ;;
+    rm | rmi )
+        if is_integer "$podman_pid"; then
+            forward_to_host
+        else
+            rm_all=false
+            rm_force=false
+            while has_prefix "$1" -; do
+                case $1 in
+                    -a | --all )
+                        rm_all=true
+                        ;;
+                    -f | --force )
+                        rm_force=true
+                        ;;
+                    * )
+                        exit_if_unrecognized_option $1
+                esac
+                shift
+            done
+
+            rm_ids=""
+            if $rm_all; then
+                exit_if_extra_operand $1
+            else
+                exit_if_missing_argument "$op" "$1"
+                while [ "$1" != "" ]; do
+                    rm_ids="$rm_ids $1"
+                    shift
+                done
+            fi
+
+            rm_ids=$(echo "$rm_ids" | sed "s/^ \+//" 2>&3)
+
+            if [ "$op" = "rm" ]; then
+                remove_containers "$rm_ids" "$rm_all" "$rm_force"
+            else
+                remove_images "$rm_ids" "$rm_all" "$rm_force"
+            fi
         fi
         exit
         ;;


### PR DESCRIPTION
Add rm and rmi commands for images/containers removal. Both commands take ID or name as an argument and if the specified image/container was created by fedora-toolbox, it's removed. 

Both commands have two flags: --all and --force. With the --all flag, the argument is not needed, as the command tries to remove all fedora-toolbox images/containers. The --force flag just runs force removal (i.e podman rm/rmi --force <ID>)