### PR TITLE
Make it work inside the toolbox container itself

### DIFF
--- a/toolbox
+++ b/toolbox
@@ -18,6 +18,7 @@
 
 exec 42>/dev/null
 
+arguments="$@"
 base_toolbox_command=$(basename "$0" 2>&42)
 base_toolbox_image=""
 environment_variables="COLORTERM \
@@ -43,6 +44,7 @@ fgc=""
 source /etc/os-release
 release=$VERSION_ID
 
+podman_pid=""
 prefix_sudo=""
 registry="registry.fedoraproject.org"
 registry_candidate="candidate-registry.fedoraproject.org"
@@ -546,6 +548,19 @@ exit_if_unrecognized_option()
 }
 
 
+forward_to_host()
+(
+    if [ "$DBUS_SYSTEM_BUS_ADDRESS" != "" ]; then
+        set_dbus_system_bus_address="--env=DBUS_SYSTEM_BUS_ADDRESS=$DBUS_SYSTEM_BUS_ADDRESS"
+    fi
+
+    set_environment_variables=$(create_environment_variable_options)
+
+    echo "$base_toolbox_command: forwarding to host: $0 $arguments" >&42
+    flatpak-spawn $set_dbus_system_bus_address $set_environment_variables --host "$0" $arguments 2>&42
+)
+
+
 update_container_and_image_names()
 {
     base_toolbox_image="fedora-toolbox:$release"
@@ -590,6 +605,42 @@ while has_prefix "$1" -; do
     shift
 done
 
+if [ -f /run/.containerenv ] 2>&42; then
+    if ! which flatpak-spawn >/dev/null 2>&42; then
+        echo "$base_toolbox_command: flatpak-spawn not found"
+        exit 1
+    fi
+
+    echo "$base_toolbox_command: looking for podman PID" >&42
+
+    pid_i=$$
+    while [ "$pid_i" -gt 1 ] 2>&42; do
+        cmdline=$(cat /proc/$pid_i/cmdline 2>&42 | sed "s/\x0/ /g" 2>&42)
+        if has_prefix "$cmdline" "podman exec "; then
+            podman_pid=$pid_i
+            break
+        fi
+
+        pid_i=$(ps -p $pid_i -o ppid= 2>&42 | sed "s/ //" 2>&42)
+        if ! is_integer "$pid_i"; then
+            echo "$base_toolbox_command: invalid parent PID"
+            break
+        fi
+    done
+
+    if ! is_integer "$podman_pid"; then
+        echo "$base_toolbox_command: invalid podman PID"
+        podman_pid=""
+    fi
+
+    if [ "$podman_pid" = "" ]; then
+        echo "$base_toolbox_command: cannot be used outside podman exec"
+        exit 1
+    fi
+
+    echo "$base_toolbox_command: podman PID is $podman_pid" >&42
+fi
+
 if [ "$1" = "" ]; then
     echo "$base_toolbox_command: missing command"
     echo "Try '$base_toolbox_command --help' for more information."
@@ -601,88 +652,100 @@ shift
 
 case $op in
     create )
-        while has_prefix "$1" -; do
-            case $1 in
-                --candidate-registry )
-                    registry=$registry_candidate
-                    ;;
-                --container )
-                    shift
-                    exit_if_missing_argument --container "$1"
-                    toolbox_container=$1
-                    ;;
-                --image )
-                    shift
-                    exit_if_missing_argument --image "$1"
-                    toolbox_image=$1
-                    ;;
-                --release )
-                    shift
-                    exit_if_missing_argument --release "$1"
-                    arg=$(echo $1 | sed "s/^F\|^f//" 2>&42)
-                    exit_if_non_positive_argument --release "$arg"
-                    release=$arg
-                    ;;
-                * )
-                    exit_if_unrecognized_option $1
-            esac
-            shift
-        done
-        exit_if_extra_operand $1
-        update_container_and_image_names
-        create
+        if is_integer "$podman_pid"; then
+            forward_to_host
+        else
+            while has_prefix "$1" -; do
+                case $1 in
+                    --candidate-registry )
+                        registry=$registry_candidate
+                        ;;
+                    --container )
+                        shift
+                        exit_if_missing_argument --container "$1"
+                        toolbox_container=$1
+                        ;;
+                    --image )
+                        shift
+                        exit_if_missing_argument --image "$1"
+                        toolbox_image=$1
+                        ;;
+                    --release )
+                        shift
+                        exit_if_missing_argument --release "$1"
+                        arg=$(echo $1 | sed "s/^F\|^f//" 2>&42)
+                        exit_if_non_positive_argument --release "$arg"
+                        release=$arg
+                        ;;
+                    * )
+                        exit_if_unrecognized_option $1
+                esac
+                shift
+            done
+            exit_if_extra_operand $1
+            update_container_and_image_names
+            create
+        fi
         exit
         ;;
     enter )
-        while has_prefix "$1" -; do
-            case $1 in
-                --container )
-                    shift
-                    exit_if_missing_argument --container "$1"
-                    toolbox_container=$1
-                    ;;
-                --release )
-                    shift
-                    exit_if_missing_argument --release "$1"
-                    arg=$(echo $1 | sed "s/^F\|^f//" 2>&42)
-                    exit_if_non_positive_argument --release "$arg"
-                    release=$arg
-                    ;;
-                * )
-                    exit_if_unrecognized_option $1
-            esac
-            shift
-        done
-        exit_if_extra_operand $1
-        update_container_and_image_names
-        enter
+        if is_integer "$podman_pid"; then
+            forward_to_host
+        else
+            while has_prefix "$1" -; do
+                case $1 in
+                    --container )
+                        shift
+                        exit_if_missing_argument --container "$1"
+                        toolbox_container=$1
+                        ;;
+                    --release )
+                        shift
+                        exit_if_missing_argument --release "$1"
+                        arg=$(echo $1 | sed "s/^F\|^f//" 2>&42)
+                        exit_if_non_positive_argument --release "$arg"
+                        release=$arg
+                        ;;
+                    * )
+                        exit_if_unrecognized_option $1
+                esac
+                shift
+            done
+            exit_if_extra_operand $1
+            update_container_and_image_names
+            enter
+        fi
         exit
         ;;
     list )
-        ls_images=false
-        ls_containers=false
-        while has_prefix "$1" -; do
-            case $1 in
-                -c | --containers )
-                    ls_containers=true
-                    ;;
-                -i | --images )
-                    ls_images=true
-                    ;;
-                * )
-                    exit_if_unrecognized_option $1
-            esac
-            shift
-        done
-        exit_if_extra_operand $1
+        if is_integer "$podman_pid"; then
+            forward_to_host
+        else
+            ls_images=false
+            ls_containers=false
+            while has_prefix "$1" -; do
+                case $1 in
+                    -c | --containers )
+                        ls_containers=true
+                        ;;
+                    -i | --images )
+                        ls_images=true
+                        ;;
+                    * )
+                        exit_if_unrecognized_option $1
+                esac
+                shift
+            done
+            exit_if_extra_operand $1
 
-        if ! $ls_containers && ! $ls_images; then
-            ls_containers=true
-            ls_images=true
+            if ! $ls_containers && ! $ls_images; then
+                ls_containers=true
+                ls_images=true
+            fi
+
+            $ls_images && list_images
+            $ls_containers && list_containers
         fi
-
-        $ls_images && list_images
-        $ls_containers && list_containers
         exit
         ;;
     * )

--- a/toolbox
+++ b/toolbox
@@ -20,6 +20,24 @@ exec 42>/dev/null
 
 base_toolbox_command=$(basename "$0" 2>&42)
 base_toolbox_image=""
+environment_variables="COLORTERM \
+        DBUS_SESSION_BUS_ADDRESS \
+        DESKTOP_SESSION \
+        DISPLAY \
+        LANG \
+        SHELL \
+        SSH_AUTH_SOCK \
+        TERM \
+        VTE_VERSION \
+        XDG_CURRENT_DESKTOP \
+        XDG_DATA_DIRS \
+        XDG_MENU_PREFIX \
+        XDG_RUNTIME_DIR \
+        XDG_SEAT \
+        XDG_SESSION_DESKTOP \
+        XDG_SESSION_ID \
+        XDG_SESSION_TYPE \
+        XDG_VTNR"
 fgc=""
 
 source /etc/os-release
@@ -213,6 +231,25 @@ configure_working_container()
 )
 
 
+create_environment_variable_options()
+{
+    echo "$environment_variables" \
+        | sed "s/ \+/\n/g" 2>&42 \
+        | {
+              environment_variable_options=""
+              echo "$base_toolbox_command: creating list of environment variables to forward" >&42
+              while read variable; do
+                  eval value="$"$variable
+                  echo "$base_toolbox_command: $variable=$value" >&42
+                  environment_variables_options="$environment_variables_options --env=$variable=$value"
+              done
+              echo "$base_toolbox_command: created options for environment variables to forward" >&42
+              echo $environment_variables_options >&42
+              echo $environment_variables_options
+          }
+}
+
+
 create()
 (
     dbus_system_bus_address="unix:path=/var/run/dbus/system_bus_socket"
@@ -392,6 +429,8 @@ enter()
         set_dbus_system_bus_address="--env DBUS_SYSTEM_BUS_ADDRESS=$DBUS_SYSTEM_BUS_ADDRESS"
     fi
 
+    set_environment_variables=$(create_environment_variable_options)
+
     echo "$base_toolbox_command: looking for $SHELL in container $toolbox_container" >&42
 
     if $prefix_sudo podman exec $toolbox_container test -f $SHELL 2>&42; then
@@ -403,25 +442,8 @@ enter()
     echo "$base_toolbox_command: trying to exec $shell_to_exec in container $toolbox_container" >&42
 
     $prefix_sudo podman exec \
-            --env COLORTERM=$COLORTERM \
-            --env DBUS_SESSION_BUS_ADDRESS=$DBUS_SESSION_BUS_ADDRESS \
             $set_dbus_system_bus_address \
-            --env DESKTOP_SESSION=$DESKTOP_SESSION \
-            --env DISPLAY=$DISPLAY \
-            --env LANG=$LANG \
-            --env SHELL=$SHELL \
-            --env SSH_AUTH_SOCK=$SSH_AUTH_SOCK \
-            --env TERM=$TERM \
-            --env VTE_VERSION=$VTE_VERSION \
-            --env XDG_CURRENT_DESKTOP=$XDG_CURRENT_DESKTOP \
-            --env XDG_DATA_DIRS=$XDG_DATA_DIRS \
-            --env XDG_MENU_PREFIX=$XDG_MENU_PREFIX \
-            --env XDG_RUNTIME_DIR=$XDG_RUNTIME_DIR \
-            --env XDG_SEAT=$XDG_SEAT \
-            --env XDG_SESSION_DESKTOP=$XDG_SESSION_DESKTOP \
-            --env XDG_SESSION_ID=$XDG_SESSION_ID \
-            --env XDG_SESSION_TYPE=$XDG_SESSION_TYPE \
-            --env XDG_VTNR=$XDG_VTNR \
+            $set_environment_variables \
             --interactive \
             --tty \
             $toolbox_container \


### PR DESCRIPTION
A truly seamless developer experience requires erasing the divide
between the host and the toolbox container as much as possible.
Currently, various tools don't work at all when used from inside the
toolbox because they expect to be run on the host. eg., buildah,
flatpak, podman, and the toolbox script itself. This puts a
significant enough cognitive burden on the developer. At the very
least, the human operator needs to keep track of the context in which
those commands are being issued.

To make things better, the toolbox script has been made aware of the
context in which it is running. If it detects that it's running inside
the toolbox container, denoted by a 'podman exec ...' parent process
and the presence of /run/.containerenv, then it tries to forward its
own invocation to the host over D-Bus using 'flatpak-spawn --host' [1].
This uses the HostCommand method on the org.freedesktop.Flatpak D-Bus
service underneath to do the forwarding.

[1] http://docs.flatpak.org/en/latest/flatpak-command-reference.html#flatpak-spawn