### PR TITLE
Remove all bashisms (resolves #53)

### DIFF
--- a/toolbox
+++ b/toolbox
@@ -123,7 +123,7 @@ spinner_start()
         return 1
     fi
 
-    echo -n "$message"
+    printf "%s" "$message"
     tput civis 2>&3
 
     exec 4>"$directory/spinner-start"
@@ -139,7 +139,7 @@ spinner_start()
                    break
                 fi
 
-                echo -n "$frame"
+                printf "%s" "$frame"
 
                 frame_len=${#frame}
                 i=0
@@ -737,7 +737,8 @@ list_images()
     fi
 
     if [ "$output" != "" ]; then
-        echo -e "${LBC}Images created by toolbox${NC}"
+        # shellcheck disable=SC2059
+        printf "${LBC}Images created by toolbox${NC}\n"
         echo "$output"
     fi
 
@@ -766,7 +767,8 @@ list_containers()
     fi
 
     if [ "$output" != "" ]; then
-        echo -e "${LBC}Containers created by toolbox${NC}"
+        # shellcheck disable=SC2059
+        printf "${LBC}Containers created by toolbox${NC}\n"
         echo "$output" | head --lines 1 2>&3
 
         echo "$output" | tail --lines +2 2>&3 \
@@ -775,7 +777,8 @@ list_containers()
                       id=$(echo "$container" | cut --delimiter " " --fields 1 2>&3)
                       is_running=$($prefix_sudo podman inspect "$id" --format "{{.State.Running}}" 2>&3)
                       if $is_running; then
-                          echo -e "${LGC}$container${NC}"
+                          # shellcheck disable=SC2059
+                          printf "${LGC}$container${NC}\n"
                       else
                           echo "$container"
                       fi


### PR DESCRIPTION
I tried to remove all bashisms, and now checkbashisms does not complain anymore:

- POSIX only supports single digit file descriptors. I used 3 instead of 42 as the file descriptor for /dev/null.
- echo -e replaces certain backslash expressions. Since, there were none of them, I just removed the -e flag. The `${variable}` syntax should still work.
- POSIX does not set the $UID environment variable. I replaced it with the custom variable $uid.
- The $'' syntax for backslash expressions does not exists in POSIX.  Since it was only used for the tab character, I just replaced it with the custom $tab variable at the beginning of the script.

In my (limited) testing, create, enter and list still works, using both bash and dash as interpreter. The --verbose option also still works, although I might have forgotten to change the file descriptor somewhere.