### PR TITLE
Work in progress: Support sound

### DIFF
--- a/toolbox
+++ b/toolbox
@@ -396,6 +396,7 @@ create()
             --volume $dbus_system_bus_path:$dbus_system_bus_path \
             --volume /dev/dri:/dev/dri \
             --volume /dev/fuse:/dev/fuse \
+            --volume /dev/snd:/dev/snd \
             $toolbox_image \
             /bin/sh >/dev/null 2>&3
     ret_val=$?


### PR DESCRIPTION
Mount /dev/snd of the host to a container as a volume.

Fix: https://github.com/debarshiray/toolbox/issues/58

It tested with liquidwar game inside containers, the sound works well.