### PR TITLE
Make the --image flag override the base toolbox image, as documented

### DIFF
--- a/toolbox
+++ b/toolbox
@@ -282,6 +282,15 @@ get_host_version_id()
 )
 
 
+image_reference_can_be_id()
+(
+    image="$1"
+
+    echo "$image" | grep "^[a-f0-9]\{6,64\}$" >/dev/null 2>&3
+    return $?
+)
+
+
 image_reference_has_domain()
 (
     # Based on the splitDockerDomain function implemented in:
@@ -305,6 +314,14 @@ image_reference_has_domain()
 pull_base_toolbox_image()
 (
     has_domain=false
+
+    if image_reference_can_be_id "$base_toolbox_image"; then
+        echo "$base_toolbox_command: looking for image $base_toolbox_image" >&3
+
+        if $prefix_sudo podman inspect --type image "$base_toolbox_image" >/dev/null 2>&3; then
+            return 0
+        fi
+    fi
 
     image_reference_has_domain "$base_toolbox_image" && has_domain=true
 

--- a/toolbox
+++ b/toolbox
@@ -274,6 +274,39 @@ create_environment_options()
 }
 
 
+create_toolbox_image_name()
+(
+    # Based on the ResolveName function implemented in:
+    # https://github.com/containers/buildah/blob/master/util/util.go
+
+    if image_reference_can_be_id "$base_toolbox_image"; then
+        if base_toolbox_image_id=$($prefix_sudo podman inspect \
+                                           --format "{{.Id}}" \
+                                           --type image \
+                                           "$base_toolbox_image" 2>&3); then
+            if has_prefix "$base_toolbox_image_id" "$base_toolbox_image"; then
+                echo "$base_toolbox_image-$USER:latest"
+                return 0
+            fi
+        fi
+    fi
+
+    basename=$(image_reference_get_basename "$base_toolbox_image")
+    if [ "$basename" = "" ] 2>&3; then
+        return 100
+    fi
+
+    tag=$(image_reference_get_tag "$base_toolbox_image")
+    if [ "$tag" = "" ] 2>&3; then
+        echo "$basename-$USER"
+    else
+        echo "$basename-$USER:$tag"
+    fi
+
+    return 0
+)
+
+
 get_host_version_id()
 (
     # shellcheck disable=SC1091
@@ -288,6 +321,43 @@ image_reference_can_be_id()
 
     echo "$image" | grep "^[a-f0-9]\{6,64\}$" >/dev/null 2>&3
     return $?
+)
+
+
+image_reference_get_basename()
+(
+    image="$1"
+
+    domain=$(image_reference_get_domain "$image")
+    remainder=${image#$domain}
+    path=${remainder%:*}
+    basename=${path##*/}
+    echo "$basename"
+)
+
+
+image_reference_get_domain()
+(
+    image="$1"
+
+    image_reference_has_domain "$image" && domain=${image%%/*}
+    echo "$domain"
+)
+
+
+image_reference_get_tag()
+(
+    image="$1"
+
+    domain=$(image_reference_get_domain "$image")
+    remainder=${image#$domain}
+
+    tag=""
+    if (echo "$remainder" | grep ":" >/dev/null 2>&3); then
+       tag=${remainder#*:}
+    fi
+
+    echo "$tag"
 )
 
 
@@ -856,10 +926,40 @@ update_container_and_image_names()
         release=$(get_host_version_id)
     fi
 
-    base_toolbox_image="fedora-toolbox:$release"
+    if [ "$base_toolbox_image" = "" ] 2>&3; then
+        base_toolbox_image="fedora-toolbox:$release"
+    else
+        release=$(image_reference_get_tag "$base_toolbox_image")
+        [ "$release" = "" ] 2>&3 && release=$(get_host_version_id)
+    fi
+
     fgc="f$release"
-    [ "$toolbox_container" = "" ] && toolbox_container="fedora-toolbox-$USER:$release"
-    [ "$toolbox_image" = "" ] && toolbox_image="fedora-toolbox-$USER:$release"
+    echo "$base_toolbox_command: Fedora generational core is $fgc" >&3
+
+    echo "$base_toolbox_command: base image is $base_toolbox_image" >&3
+
+    toolbox_image=$(create_toolbox_image_name)
+    if ! (
+            ret_val=$?
+            if [ "$ret_val" -ne 0 ] 2>&3; then
+                if [ "$ret_val" -eq 100 ] 2>&3; then
+                    echo "$base_toolbox_command: failed to get the basename of base image $base_toolbox_image" >&2
+                else
+                    echo "$base_toolbox_command: failed to create an ID for the customized user-specific image" >&2
+                fi
+
+                exit 1
+            fi
+
+            exit 0
+         ); then
+        exit 1
+    fi
+
+    echo "$base_toolbox_command: customized user-specific image is $toolbox_image" >&3
+
+    [ "$toolbox_container" = "" ] && toolbox_container="$toolbox_image"
+    echo "$base_toolbox_command: container is $toolbox_container" >&3
 }
 
 
@@ -966,7 +1066,7 @@ case $op in
                     --image )
                         shift
                         exit_if_missing_argument --image "$1"
-                        toolbox_image=$1
+                        base_toolbox_image=$1
                         ;;
                     --release )
                         shift

--- a/toolbox
+++ b/toolbox
@@ -282,18 +282,50 @@ get_host_version_id()
 )
 
 
-pull_base_toolbox_image()
+image_reference_has_domain()
 (
-    echo "$base_toolbox_command: looking for image localhost/$base_toolbox_image" >&3
+    # Based on the splitDockerDomain function implemented in:
+    # https://github.com/docker/distribution/blob/master/reference/normalize.go
 
-    if $prefix_sudo buildah pull localhost/$base_toolbox_image >/dev/null 2>&3; then
-        return 0
+    image="$1"
+
+    if ! (echo "$image" | grep "/" >/dev/null 2>&3); then
+        return 1
     fi
 
-    echo "$base_toolbox_command: looking for image $registry/$fgc/$base_toolbox_image" >&3
+    prefix=${image%%/*}
+    if ! (echo "$prefix" | grep "[.:]" >/dev/null 2>&3) && [ "$prefix" != "localhost" ] 2>&3; then
+       return 1
+    fi
+
+    return 0
+)
+
+
+pull_base_toolbox_image()
+(
+    has_domain=false
+
+    image_reference_has_domain "$base_toolbox_image" && has_domain=true
+
+    if ! $has_domain; then
+        echo "$base_toolbox_command: looking for image localhost/$base_toolbox_image" >&3
+
+        if $prefix_sudo buildah pull localhost/$base_toolbox_image >/dev/null 2>&3; then
+            return 0
+        fi
+    fi
+
+    if $has_domain; then
+        base_toolbox_image_full="$base_toolbox_image"
+    else
+        base_toolbox_image_full="$registry/$fgc/$base_toolbox_image"
+    fi
+
+    echo "$base_toolbox_command: looking for image $base_toolbox_image_full" >&3
 
     if spinner_directory=$(mktemp --directory --tmpdir $spinner_template 2>&3); then
-        spinner_message="$base_toolbox_command: pulling from $registry: "
+        spinner_message="$base_toolbox_command: pulling $base_toolbox_image_full: "
         if ! spinner_start "$spinner_directory" "$spinner_message"; then
             spinner_directory=""
         fi
@@ -302,7 +334,7 @@ pull_base_toolbox_image()
         spinner_directory=""
     fi
 
-    $prefix_sudo buildah pull $registry/$fgc/$base_toolbox_image >/dev/null 2>&3
+    $prefix_sudo buildah pull $base_toolbox_image_full >/dev/null 2>&3
     ret_val=$?
 
     if [ "$spinner_directory" != "" ]; then
@@ -334,15 +366,20 @@ create()
             exit 1
         fi
 
-        if ! base_toolbox_image_full=$($prefix_sudo podman inspect \
-                                               --format "{{index .RepoTags 0}}" \
-                                               --type image \
-                                               "$base_toolbox_image" 2>&3); then
-            echo "$base_toolbox_command: failed to get RepoTag for base image $base_toolbox_image" >&2
-            exit 1
+        if image_reference_has_domain "$base_toolbox_image"; then
+            base_toolbox_image_full="$base_toolbox_image"
+        else
+            if ! base_toolbox_image_full=$($prefix_sudo podman inspect \
+                                                   --format "{{index .RepoTags 0}}" \
+                                                   --type image \
+                                                   "$base_toolbox_image" 2>&3); then
+                echo "$base_toolbox_command: failed to get RepoTag for base image $base_toolbox_image" >&2
+                exit 1
+            fi
+
+            echo "$base_toolbox_command: base image $base_toolbox_image resolved to $base_toolbox_image_full" >&3
         fi
 
-        echo "$base_toolbox_command: base image $base_toolbox_image resolved to $base_toolbox_image_full" >&3
         echo "$base_toolbox_command: trying to create working container $working_container_name" >&3
 
         if spinner_directory=$(mktemp --directory --tmpdir $spinner_template 2>&3); then


### PR DESCRIPTION
The current implementation of the --image flag, including the commit
message in commit 31de3ff96fe4eea2 that added it, was a total fiasco
and didn't match the intended behaviour or the documentation in the
manual at all. At the moment it overrides the name of the user-specific
customized image. This doesn't make sense because it's mostly an
implementation detail of the toolbox script - a way to get from the
base image to a toolbox container that's seamlessly integrated with the
host.

In other words, there's no need for a separate flag to allow having
multiple user-specific customized images from the same base image. It
already happens as a side effect of creating multiple toolbox
containers from the same base image using the --container flag.

What it really should do is override the base image so that toolbox
containers with different content can be created.

Fallout from 31de3ff96fe4eea29259a1d50847b97f19e8d50b