### PR TITLE
added short options for create and enter

### DIFF
--- a/doc/toolbox-create.1.md
+++ b/doc/toolbox-create.1.md
@@ -5,9 +5,9 @@ toolbox\-create - Create a new toolbox container
 
 ## SYNOPSIS
 **toolbox create** [*--candidate-registry*]
-               [*--container NAME*]
-               [*--image NAME*]
-               [*--release RELEASE*]
+               [*--container NAME* | *-c NAME*]
+               [*--image NAME* | *-i NAME*]
+               [*--release RELEASE* | *-r RELEASE*]
 
 ## DESCRIPTION
 
@@ -35,18 +35,18 @@ Pull the base image from `candidate-registry.fedoraproject.org`. This is
 useful for testing newly built images before they have moved to the stable
 registry at `registry.fedoraproject.org`.
 
-**--container** NAME
+**--container** NAME, **-c** NAME
 
 Assign a different NAME to the toolbox container. This is useful for creating
 multiple toolbox containers from the same base image, or for entirely
 customized containers from custom-built base images.
 
-**--image** NAME
+**--image** NAME, **-i** NAME
 
 Change the NAME of the base image used to create the toolbox container. This
 is useful for creating containers from custom-built base images.
 
-**--release** RELEASE
+**--release** RELEASE, **-r** RELEASE
 
 Create a toolbox container for a different operating system RELEASE than the
 host.

--- a/doc/toolbox-enter.1.md
+++ b/doc/toolbox-enter.1.md
@@ -4,7 +4,8 @@
 toolbox\-enter - Enter an existing toolbox container for interactive use
 
 ## SYNOPSIS
-**toolbox enter** [*--container NAME*] [*--release RELEASE*]
+**toolbox enter** [*--container NAME* | *-c NAME*]
+              [*--release RELEASE* | *-r RELEASE*]
 
 ## DESCRIPTION
 
@@ -22,13 +23,13 @@ of the base image and suffixed with the current user name.
 
 The following options are understood:
 
-**--container** NAME
+**--container** NAME, **-c** NAME
 
 Enter a toolbox container with the given NAME. This is useful when there are
 multiple toolbox containers created from the same base image, or entirely
 customized containers created from custom-built base images.
 
-**--release** RELEASE
+**--release** RELEASE, **-r** RELEASE
 
 Enter a toolbox container for a different operating system RELEASE than the
 host.

--- a/toolbox
+++ b/toolbox
@@ -1228,12 +1228,12 @@ usage()
 {
     echo "Usage: toolbox [-v | --verbose]"
     echo "               create [--candidate-registry]"
-    echo "                      [--container <name>]"
-    echo "                      [--image <name>]"
-    echo "                      [--release <release>]"
+    echo "                      [-c | --container <name>]"
+    echo "                      [-i | --image <name>]"
+    echo "                      [-r | --release <release>]"
     echo "   or: toolbox [-v | --verbose]"
-    echo "               enter [--container <name>]"
-    echo "                     [--release <release>]"
+    echo "               enter [-c | --container <name>]"
+    echo "                     [-r | --release <release>]"
     echo "   or: toolbox [-v | --verbose]"
     echo "               list [-c | --containers]"
     echo "                    [-i | --images]"
@@ -1332,7 +1332,7 @@ case $op in
                     --candidate-registry )
                         registry=$registry_candidate
                         ;;
-                    --container )
+                    -c | --container )
                         shift
                         exit_if_missing_argument --container "$1"
                         arg=$1
@@ -1344,12 +1344,12 @@ case $op in
                         fi
                         toolbox_container="$arg"
                         ;;
-                    --image )
+                    -i | --image )
                         shift
                         exit_if_missing_argument --image "$1"
                         base_toolbox_image=$1
                         ;;
-                    --release )
+                    -r | --release )
                         shift
                         exit_if_missing_argument --release "$1"
                         arg=$(echo "$1" | sed "s/^F\|^f//" 2>&3)
@@ -1374,12 +1374,12 @@ case $op in
         else
             while has_prefix "$1" -; do
                 case $1 in
-                    --container )
+                    -c | --container )
                         shift
                         exit_if_missing_argument --container "$1"
                         toolbox_container=$1
                         ;;
-                    --release )
+                    -r | --release )
                         shift
                         exit_if_missing_argument --release "$1"
                         arg=$(echo "$1" | sed "s/^F\|^f//" 2>&3)


### PR DESCRIPTION
having short options for enter and create would be nice as i'm calling these quite often. i didn't add a short option for `create --candidate-registry`, `-r` is already taken and i'm currently not using `--candidate-registry`.

thanks
toni