### PR TITLE
implement run command

### DIFF
--- a/doc/toolbox-run.1.md
+++ b/doc/toolbox-run.1.md
@@ -1,0 +1,59 @@
+% toolbox-run(1)
+
+## NAME
+toolbox\-run - Run a command in an existing toolbox container
+
+## SYNOPSIS
+**toolbox run** [*-c | --container NAME*] [*-r | --release RELEASE*] [*COMMAND*]
+
+## DESCRIPTION
+
+Runs a command inside an existing toolbox container. The container
+should have been created using the `toolbox create` command.
+
+A toolbox container is an OCI container. Therefore, `toolbox run` is
+analogous to a `podman start` followed by a `podman exec`.
+
+On Fedora the toolbox containers are tagged with the version of the OS that
+corresponds to the content inside them. Their names are prefixed with the name
+of the base image and suffixed with the current user name.
+
+## OPTIONS ##
+
+The following options are understood:
+
+**-c | --container** NAME
+
+Run command inside a toolbox container with the given NAME. This is
+useful when there are multiple toolbox containers created from the
+same base image, or entirely customized containers created from
+custom-built base images.
+
+**-r | --release** RELEASE
+
+Run command inside a toolbox container for a different operating
+system RELEASE than the host.
+
+## EXAMPLES
+
+### Run ls inside a toolbox container using the default image matching the host OS
+
+```
+$ toolbox run ls -la
+```
+
+### Run emacs inside a toolbox container using the default image for Fedora 30
+
+```
+$ toolbox run --release f30 emacs
+```
+
+### Run uptime inside a custom toolbox container using a custom image
+
+```
+$ toolbox run --container foo cat /etc/fedora-release
+```
+
+## SEE ALSO
+
+`buildah(1)`, `podman(1)`, `podman-exec(1)`, `podman-start(1)`

--- a/toolbox
+++ b/toolbox
@@ -946,6 +946,15 @@ enter()
     create_toolbox_container=false
     prompt_for_create=true
     shell_to_exec=/bin/bash
+    run "PS1=\"$toolbox_prompt\" $shell_to_exec" "$SHELL" "--interactive --tty"
+)
+
+
+run()
+(
+    command="cd $PWD; $1"
+    fallback_command="$2"
+    podman_extra_arguments="$3"
 
     echo "$base_toolbox_command: checking if container $toolbox_container exists" >&3
 
@@ -953,7 +962,7 @@ enter()
                                  --format "{{.ImageName}}" \
                                  --type container \
                                  $toolbox_container 2>&3); then
-        echo "$base_toolbox_command: checking if container $toolbox_container_old exists" >&3
+	echo "$base_toolbox_command: checking if container $toolbox_container_old exists" >&3
 
         if toolbox_image=$($prefix_sudo podman inspect \
                                    --format "{{.ImageName}}" \
@@ -1033,29 +1042,25 @@ enter()
 
     set_environment=$(create_environment_options)
 
-    echo "$base_toolbox_command: looking for $SHELL in container $toolbox_container" >&3
-
-    if $prefix_sudo podman exec "$toolbox_container" test -f "$SHELL" 2>&3; then
-        shell_to_exec="$SHELL"
-    else
-        echo "$base_toolbox_command: $SHELL not found in $toolbox_container; using $shell_to_exec instead" >&3
+    if [ "$fallback_command" != "" ]; then
+	binary=$(echo "$command" | cut -d ' ' -f 1)
+	if $prefix_sudo podman exec $toolbox_container test -x "$binary" 2>&3; then
+	    echo "$base_toolbox_command: $binary not found in $toolbox_container; using $fallback_command instead" >&3
+            command=$fallback_command
+	fi
     fi
 
-    echo "$base_toolbox_command: trying to exec $shell_to_exec in container $toolbox_container" >&3
+    echo "$base_toolbox_command: trying to run '$command' in container $toolbox_container" >&3
 
     # shellcheck disable=SC2016
     # for the command passed to capsh
     # shellcheck disable=SC2086
     $prefix_sudo podman exec \
+            $podman_extra_arguments \
+            $set_dbus_system_bus_address \
             $set_environment \
-            --interactive \
-            --tty \
-            "$toolbox_container" \
-            capsh --caps="" -- -c 'cd "$1"; export PS1="$2"; shift 2; exec "$@"' \
-                    /bin/sh \
-                    "$PWD" \
-                    "$toolbox_prompt" \
-                    "$shell_to_exec" -l 2>&3
+            $toolbox_container \
+            capsh --caps="" -- -c "$command"
 )
 
 
@@ -1473,6 +1478,9 @@ usage()
     echo "   or: toolbox [-y | --assumeyes]"
     echo "               rmi [-a | --all]"
     echo "                   [-f | --force] [<image> ...]"
+    echo "   or: toolbox [-v | --verbose]"
+    echo "               run [-c | --container <name>]"
+    echo "                   [-r | --release <release>]"
     echo "   or: toolbox --help"
 }
 
@@ -1744,6 +1752,35 @@ case $op in
             else
                 remove_images "$rm_ids" "$rm_all" "$rm_force"
             fi
+        fi
+        exit
+        ;;
+    run )
+        if is_integer "$podman_pid"; then
+	    # shellcheck disable=SC2119
+            forward_to_host
+        else
+            while has_prefix "$1" -; do
+                case $1 in
+                    -c | --container )
+                        shift
+                        exit_if_missing_argument --container "$1"
+                        toolbox_container=$1
+                        ;;
+                    -r | --release )
+                        shift
+                        exit_if_missing_argument --release "$1"
+                        arg=$(echo "$1" | sed "s/^F\|^f//" 2>&3)
+                        exit_if_non_positive_argument --release "$arg"
+                        release=$arg
+                        ;;
+                    * )
+                        exit_if_unrecognized_option "$1"
+                esac
+                shift
+            done
+            update_container_and_image_names
+            run "$*"
         fi
         exit
         ;;


### PR DESCRIPTION
this is my shot at implementing a `toolbox run` command. it simply runs a command in the toolbox container given. 

the use case is that we do not have to enter the container before running various commands. i've various aliases defined using the run command:

```
alias emacs='toolbox run -c home emacs'
alias vlc='toolbox run -c home vlc'
```

currently the documentation is missing, i will update the pull request if there is a chance that this gets merged.

i'm not a shell programming expert, so please be patient and excuse any mistakes :-)

thanks for this great tool
toni

**edit:** fixed typo