### PR TITLE
images: Always install "selinux-policy-targeted"

### DIFF
--- a/images/fedora/f28/extra-packages
+++ b/images/fedora/f28/extra-packages
@@ -36,3 +36,4 @@ which
 words
 xz
 zip
+selinux-policy-targeted

--- a/images/fedora/f29/extra-packages
+++ b/images/fedora/f29/extra-packages
@@ -37,3 +37,4 @@ which
 words
 xz
 zip
+selinux-policy-targeted

--- a/images/fedora/f30/extra-packages
+++ b/images/fedora/f30/extra-packages
@@ -37,3 +37,4 @@ which
 words
 xz
 zip
+selinux-policy-targeted


### PR DESCRIPTION
rpm-plugin-selinux which is pulled by default in images can fail
if no SELINUX policy is installed or found. This causes users to
run into issues with dnf, which surpresses the error messages and
instead complains about "failing to obtain the transaction lock",
which is unrelated to the issue.

With the default SELINUX policy set to "targeted" without having
the targeted context files causes the system to be in an
inconsistent state.

A fix for RPM to propagate the error message has been pushed in
https://github.com/rpm-software-management/rpm/commit/8cbe8baf9c

There has been proposed a selinux-policy fix to check for config
file's consistency and install the proper policy if not.
https://src.fedoraproject.org/rpms/selinux-policy/pull-request/15

This should be available in the F31 image, therefore I am leaving
it out from the f31/extra-packages list.