### PR TITLE
Fix the saving and restoring of the array of positional parameters

### DIFF
--- a/toolbox
+++ b/toolbox
@@ -18,7 +18,7 @@
 
 exec 3>/dev/null
 
-arguments="$@"
+arguments=""
 base_toolbox_command=$(basename "$0" 2>&3)
 base_toolbox_image=""
 environment_variables="COLORTERM \
@@ -105,6 +105,15 @@ is_integer()
 {
     [ "$1" != "" ] && [ "$1" -eq "$1" ] 2>&3
     return $?
+}
+
+
+save_positional_parameters()
+{
+    for i; do
+        printf "%s\\n" "$i" | sed "s/'/'\\\\''/g;1s/^/'/;\$s/\$/' \\\\/" 2>&3
+    done
+    echo " "
 }
 
 
@@ -964,16 +973,24 @@ exit_if_unrecognized_option()
 }
 
 
+# shellcheck disable=SC2120
 forward_to_host()
 (
+    eval "set -- $arguments"
+
     if [ "$DBUS_SYSTEM_BUS_ADDRESS" != "" ]; then
         set_dbus_system_bus_address="--env=DBUS_SYSTEM_BUS_ADDRESS=$DBUS_SYSTEM_BUS_ADDRESS"
     fi
 
     set_environment=$(create_environment_options)
 
-    echo "$base_toolbox_command: forwarding to host: $0 $arguments" >&3
-    flatpak-spawn $set_dbus_system_bus_address $set_environment --host "$0" $arguments 2>&3
+    echo "$base_toolbox_command: forwarding to host:" >&3
+    echo "$base_toolbox_command: $0" >&3
+    for i in "$@"; do
+        echo "$base_toolbox_command: $i" >&3
+    done
+
+    flatpak-spawn $set_dbus_system_bus_address $set_environment --host "$0" "$@" 2>&3
 )
 
 
@@ -1040,6 +1057,8 @@ usage()
     echo "   or: toolbox --help"
 }
 
+
+arguments=$(save_positional_parameters "$@")
 
 while has_prefix "$1" -; do
     case $1 in
@@ -1108,6 +1127,7 @@ shift
 case $op in
     create )
         if is_integer "$podman_pid"; then
+            # shellcheck disable=SC2119
             forward_to_host
         else
             while has_prefix "$1" -; do
@@ -1145,6 +1165,7 @@ case $op in
         ;;
     enter )
         if is_integer "$podman_pid"; then
+            # shellcheck disable=SC2119
             forward_to_host
         else
             while has_prefix "$1" -; do
@@ -1174,6 +1195,7 @@ case $op in
         ;;
     list )
         if is_integer "$podman_pid"; then
+            # shellcheck disable=SC2119
             forward_to_host
         else
             ls_images=false
@@ -1217,6 +1239,7 @@ case $op in
         ;;
     rm | rmi )
         if is_integer "$podman_pid"; then
+            # shellcheck disable=SC2119
             forward_to_host
         else
             rm_all=false


### PR DESCRIPTION
Otherwise https://www.shellcheck.net/ would complain:
  Line 21:
  arguments="$@"
            ^-- SC2124: Assigning an array to a string! Assign as
              array, or use * instead of @ to concatenate.

See: https://github.com/koalaman/shellcheck/wiki/SC2124

POSIX doesn't support arrays other than the one for positional
parameters (ie. "$@"); and "$@" is generally recommended for
forwarding the positional parameters, not $@ or "$*" or $* [1,2].

Therefore, the original contents of "$@" are saved in a scalar variable
after quoting them in a way that's resilient against spaces and
wildcards in the elements, and are later restored using 'set -- ...'
based on Rich's sh (POSIX shell) tricks:
http://www.etalabs.net/sh_tricks.html

Since the forward_to_host to function isn't passed any positional
parameters but still references "$@", because it uses 'set -- ...' to
restore the script's array of positional parameters, SC2119 [3] and
SC2120 [4] need to be silenced. Otherwise https://www.shellcheck.net/
would complain:
  Line 976:
  forward_to_host()
  ^-- SC2120: forward_to_host references arguments, but none are ever
    passed.

The --verbose debug output was restructured to silence SC2145 [5].
Otherwise https://www.shellcheck.net/ would complain:
  Line 986:
  echo "... to host: $0 $@" >&3
                        ^-- SC2145: Argument mixes string and array.
                          Use * or separate argument.

As a nice side-effect the new output highlights the importance of using
"$@" to forward the positional parameters instead of the other
alternatives.

Fallout from 5b3d234c9e9ef45ff3540d5febc799277cf747d9

[1] https://unix.stackexchange.com/questions/41571/what-is-the-difference-between-and/94200
[2] https://unix.stackexchange.com/questions/129072/whats-the-difference-between-and
[3] https://github.com/koalaman/shellcheck/wiki/SC2119
[4] https://github.com/koalaman/shellcheck/wiki/SC2120
[5] https://github.com/koalaman/shellcheck/wiki/SC2145

https://github.com/debarshiray/toolbox/pull/83