### PR TITLE
Initialize the variable before assigning to it with eval

### DIFF
--- a/toolbox
+++ b/toolbox
@@ -283,6 +283,7 @@ create_environment_options()
         | {
               environment_options=""
               echo "$base_toolbox_command: creating list of environment variables to forward" >&3
+              value=""
               while read -r variable; do
                   eval value="$""$variable"
                   echo "$base_toolbox_command: $variable=$value" >&3


### PR DESCRIPTION
Otherwise https://www.shellcheck.net/ would complain:
  Line 288:
  echo "$base_toolbox_command: $variable=$value" >&3
                                         ^-- SC2154: value is
                                           referenced but not assigned.

See: https://github.com/koalaman/shellcheck/wiki/SC2154

https://github.com/debarshiray/toolbox/pull/83