### PR TITLE
Silence SC2016

### DIFF
--- a/toolbox
+++ b/toolbox
@@ -745,6 +745,8 @@ enter()
 
     echo "$base_toolbox_command: trying to exec $shell_to_exec in container $toolbox_container" >&3
 
+    # shellcheck disable=SC2016
+    # for the command passed to capsh
     $prefix_sudo podman exec \
             $set_dbus_system_bus_address \
             $set_environment \


### PR DESCRIPTION
Otherwise https://www.shellcheck.net/ would complain:
  Line 754:
  capsh --caps="" -- -c 'cd "$1"; export PS1="$2"; shift 2; exec "$@"'
                        ^-- SC2016: Expressions don't expand in single
                          quotes, use double quotes for that.

See: https://github.com/koalaman/shellcheck/wiki/SC2016

The entire command string argument is meant to be passed as is,
without any variable expansion, to the shell started by capsh(1) inside
the toolbox container.

https://github.com/debarshiray/toolbox/pull/83