### PR TITLE
Use a lighter entry point than /bin/sh

### DIFF
--- a/toolbox
+++ b/toolbox
@@ -665,14 +665,12 @@ create()
     $prefix_sudo podman create \
             --group-add wheel \
             --hostname toolbox \
-            --interactive \
             --name $toolbox_container \
             --network host \
             --pid host \
             --privileged \
             --security-opt label=disable \
             --tmpfs /dev/shm:size=$tmpfs_size \
-            --tty \
             --uidmap "$user_id_real":0:1 \
             --uidmap 0:1:"$user_id_real" \
             --uidmap "$uid_plus_one":"$uid_plus_one":"$max_minus_uid" \
@@ -687,7 +685,7 @@ create()
             --volume /mnt:/mnt:rslave \
             --volume /run/media:/run/media:rslave \
             $toolbox_image \
-            /bin/sh >/dev/null 2>&3
+            sleep +Inf >/dev/null 2>&3
     ret_val=$?
 
     if [ "$spinner_directory" != "" ]; then


### PR DESCRIPTION
Now that toolbox containers no longer use a separate PID namespace [1],
the entry point specified in 'podman create ...' doesn't act as PID 1
inside the toolbox container. It's just a process that's spawned by
'podman start' to denote the state of the container. This opens the
possibility of using something even more lightweight, such as
'sleep +Inf'.

sleep(1) takes 64 kB compared to the 432 kB taken by /bin/sh.

This wouldn't have been possible with a separate PID namespace. In that
case, the entry point would also become PID 1, and since the only
signals that can be sent to a PID 1 are those for which it has
explicitly installed handlers, this would cause various problems.

[1] Commit 67522f0ad7637768