### PR TITLE
Change volume mounts to include all of /dev.

### DIFF
--- a/toolbox
+++ b/toolbox
@@ -777,9 +777,7 @@ create()
             --volume "$XDG_RUNTIME_DIR"/.flatpak-helper/monitor:/run/host/monitor \
             --volume "$dbus_system_bus_path":"$dbus_system_bus_path" \
             --volume /etc:/run/host/etc \
-            --volume /dev/bus:/dev/bus \
-            --volume /dev/dri:/dev/dri \
-            --volume /dev/fuse:/dev/fuse \
+            --volume /dev:/dev:rslave \
             --volume /media:/media:rslave \
             --volume /mnt:/mnt:rslave \
             --volume /run/media:/run/media:rslave \


### PR DESCRIPTION
This is useful for accessing devices such as ttyUSB* which wouldn't
previously appear in the /dev tree when in a toolbox container.

This is a simple solution to #97, passing the entirety of `/dev` into the container, rather than mounting specific portions of it. There may be some security concerns to address when using this particular approach, especially as the container is being run with the `privileged` flag.

EDIT: It should be noted that while the /dev tree is passed into the container, `/dev` belongs to `nobody:nobody` and as such files are unaccessible without changing permissions on the host.