### PR TITLE
Show a welcome text on interactive shells running inside a toolbox

### DIFF
--- a/profile.d/toolbox.sh
+++ b/profile.d/toolbox.sh
@@ -3,6 +3,7 @@
 
 toolbox_config="$HOME/.config/toolbox"
 host_welcome_stub="$toolbox_config/host-welcome-shown"
+toolbox_welcome_stub="$toolbox_config/toolbox-welcome-shown"
 
 if [ -f /run/ostree-booted ] \
    && ! [ -f "$host_welcome_stub" ]; then
@@ -22,5 +23,26 @@ if [ -f /run/ostree-booted ] \
     touch "$host_welcome_stub"
 fi
 
+if [ -f /run/.containerenv ] \
+   && ! [ -f "$toolbox_welcome_stub" ] \
+   && [ "$TOOLBOX_PATH" != "" ]; then
+    echo ""
+    echo "Welcome to the Toolbox; a container where you can install and run"
+    echo "all your tools."
+    echo ""
+    echo " - Use DNF in the usual manner to install command line tools."
+    echo " - To create a new tools container, run 'toolbox create'."
+    echo ""
+    printf "For more information, see the "
+    # shellcheck disable=SC1003
+    printf '\033]8;;https://docs.fedoraproject.org/en-US/fedora-silverblue/toolbox/\033\\documentation\033]8;;\033\\'
+    printf ".\n"
+    echo ""
+
+    mkdir -p "$toolbox_config"
+    touch "$toolbox_welcome_stub"
+fi
+
 unset toolbox_config
 unset host_welcome_stub
+unset toolbox_welcome_stub


### PR DESCRIPTION
The welcome text uses the OSC 8 [1] escape sequence to add a hyperlink
to the Silverblue documentation [2].

Silence a SC1003 [3] because the intention is to print the 'ESC \'
string terminator (or ST), and not escape a single quote.

[1] https://gist.github.com/egmontkob/eb114294efbcd5adb1944c9f3cb5feda
[2] https://docs.fedoraproject.org/en-US/fedora-silverblue/toolbox/
[3] https://github.com/koalaman/shellcheck/wiki/SC1003