### PR TITLE
Make 'toolbox enter' create or fallback to a container when possible

### DIFF
--- a/toolbox
+++ b/toolbox
@@ -501,6 +501,29 @@ images_get_details()
 )
 
 
+list_container_names()
+(
+    if ! containers_old=$($prefix_sudo podman ps \
+                                  --all \
+                                  --filter "label=com.redhat.component=fedora-toolbox" \
+                                  --format "{{.Names}}" 2>&3); then
+        echo "$base_toolbox_command: failed to list containers with com.redhat.component=fedora-toolbox" >&2
+        return 1
+    fi
+
+    if ! containers=$($prefix_sudo podman ps \
+                              --all \
+                              --filter "label=com.github.debarshiray.toolbox=true" \
+                              --format "{{.Names}}" 2>&3); then
+        echo "$base_toolbox_command: failed to list containers with com.github.debarshiray.toolbox=true" >&2
+        return 1
+    fi
+
+    printf "%s\n%s\n" "$containers_old" "$containers" | sort 2>&3 | uniq 2>&3
+    return 0
+)
+
+
 pull_base_toolbox_image()
 (
     domain=""
@@ -949,23 +972,10 @@ containers_get_details()
 
 list_containers()
 (
-    if ! containers_old=$($prefix_sudo podman ps \
-                                  --all \
-                                  --filter "label=com.redhat.component=fedora-toolbox" \
-                                  --format "{{.Names}}" 2>&3); then
-        echo "$base_toolbox_command: failed to list containers with com.redhat.component=fedora-toolbox" >&2
+    if ! containers=$(list_container_names); then
         return 1
     fi
 
-    if ! containers=$($prefix_sudo podman ps \
-                              --all \
-                              --filter "label=com.github.debarshiray.toolbox=true" \
-                              --format "{{.Names}}" 2>&3); then
-        echo "$base_toolbox_command: failed to list containers with com.github.debarshiray.toolbox=true" >&2
-        return 1
-    fi
-
-    containers=$(printf "%s\n%s\n" "$containers_old" "$containers" | sort 2>&3 | uniq 2>&3)
     if ! details=$(containers_get_details "$containers"); then
         return 1
     fi

--- a/toolbox
+++ b/toolbox
@@ -640,6 +640,8 @@ pull_base_toolbox_image()
 
 create()
 (
+    enter_command_skip="$1"
+
     dbus_system_bus_address="unix:path=/var/run/dbus/system_bus_socket"
     kcm_ccache_configuration=""
     kcm_socket=""
@@ -857,8 +859,11 @@ create()
         return 1
     fi
 
-    echo "Created container: $toolbox_container"
-    echo "Enter with: $enter_command"
+    if ! $enter_command_skip; then
+        echo "Created container: $toolbox_container"
+        echo "Enter with: $enter_command"
+    fi
+
     return 0
 )
 
@@ -1492,7 +1497,7 @@ case $op in
             if ! update_container_and_image_names; then
                 exit 1
             fi
-            if ! create; then
+            if ! create false; then
                 exit 1
             fi
         fi

--- a/toolbox
+++ b/toolbox
@@ -206,6 +206,35 @@ spinner_stop()
 )
 
 
+ask_for_confirmation()
+(
+    default_response="$1"
+    prompt="$2"
+    ret_val=0
+
+    while :; do
+        printf "%s " "$prompt"
+        read -r user_response
+
+        if [ "$user_response" = "" ] 2>&3; then
+            user_response="$default_response"
+        else
+            user_response=$(echo "$user_response" | tr "[:upper:]" "[:lower:]" 2>&3)
+        fi
+
+        if [ "$user_response" = "no" ] 2>&3 || [ "$user_response" = "n" ] 2>&3; then
+            ret_val=1
+            break
+        elif [ "$user_response" = "yes" ] 2>&3 || [ "$user_response" = "y" ] 2>&3; then
+            ret_val=0
+            break
+        fi
+    done
+
+    return "$ret_val"
+)
+
+
 check_image_for_volumes()
 (
     image="$1"
@@ -570,24 +599,12 @@ pull_base_toolbox_image()
     if $prompt_for_download; then
         echo "Image required to create toolbox container."
 
-        while :; do
-            printf "Download %s (500MB)? [y/N]: " "$base_toolbox_image_full"
-            read -r user_response
-
-            if [ "$user_response" = "" ] 2>&3; then
-                user_response="n"
-            else
-                user_response=$(echo "$user_response" | tr "[:upper:]" "[:lower:]" 2>&3)
-            fi
-
-            if [ "$user_response" = "no" ] 2>&3 || [ "$user_response" = "n" ] 2>&3; then
-                pull_image=false
-                break
-            elif [ "$user_response" = "yes" ] 2>&3 || [ "$user_response" = "y" ] 2>&3; then
-                pull_image=true
-                break
-            fi
-        done
+        prompt=$(printf "Download %s (500MB)? [y/N]:" "$base_toolbox_image_full")
+        if ask_for_confirmation "n" "$prompt"; then
+            pull_image=true
+        else
+            pull_image=false
+        fi
     fi
 
     if ! $pull_image; then

--- a/toolbox
+++ b/toolbox
@@ -650,7 +650,7 @@ create()
 
     if ! $prefix_sudo podman image exists $toolbox_image >/dev/null 2>&3; then
         if ! pull_base_toolbox_image; then
-            exit 1
+            return 1
         fi
 
         if image_reference_has_domain "$base_toolbox_image"; then
@@ -661,7 +661,7 @@ create()
                                                    --type image \
                                                    "$base_toolbox_image" 2>&3); then
                 echo "$base_toolbox_command: failed to get RepoTag for base image $base_toolbox_image" >&2
-                exit 1
+                return 1
             fi
 
             echo "$base_toolbox_command: base image $base_toolbox_image resolved to $base_toolbox_image_full" >&3
@@ -688,7 +688,7 @@ create()
 
         if [ $ret_val -ne 0 ]; then
             echo "$base_toolbox_command: failed to create working container" >&2
-            exit 1
+            return 1
         fi
 
         echo "$base_toolbox_command: trying to configure working container $working_container_name" >&3
@@ -712,7 +712,7 @@ create()
 
         if [ $ret_val -ne 0 ]; then
             $prefix_sudo buildah rm "$working_container_name" >/dev/null 2>&3
-            exit 1
+            return 1
         fi
 
         echo "$base_toolbox_command: trying to create image $toolbox_image" >&3
@@ -737,7 +737,7 @@ create()
         if [ $ret_val -ne 0 ]; then
             $prefix_sudo buildah rm "$working_container_name" >/dev/null 2>&3
             echo "$base_toolbox_command: failed to create image $toolbox_image" >&2
-            exit 1
+            return 1
         fi
 
         echo "$base_toolbox_command: created image $toolbox_image" >&3
@@ -752,7 +752,7 @@ create()
         echo "$base_toolbox_command: container $toolbox_container already exists" >&2
         echo "Enter with: $enter_command" >&2
         echo "Try '$base_toolbox_command --help' for more information." >&2
-        exit 1
+        return 1
     fi
 
     total_ram=$(awk '( $1 == "MemTotal:" ) { print $2 }' /proc/meminfo 2>&3) # kibibytes
@@ -814,11 +814,12 @@ create()
 
     if [ $ret_val -ne 0 ]; then
         echo "$base_toolbox_command: failed to create container $toolbox_container" >&2
-        exit 1
+        return 1
     fi
 
     echo "Created container: $toolbox_container"
     echo "Enter with: $enter_command"
+    return 0
 )
 
 
@@ -1464,7 +1465,9 @@ case $op in
             if ! update_container_and_image_names; then
                 exit 1
             fi
-            create
+            if ! create; then
+                exit 1
+            fi
         fi
         exit
         ;;

--- a/toolbox
+++ b/toolbox
@@ -426,6 +426,16 @@ create_toolbox_image_name()
 )
 
 
+enter_print_container_not_found()
+(
+    container="$1"
+
+    echo "$base_toolbox_command: container $container not found" >&2
+    echo "Use the 'create' command to create a toolbox." >&2
+    echo "Try '$base_toolbox_command --help' for more information." >&2
+)
+
+
 get_host_id()
 (
     # shellcheck disable=SC1091
@@ -870,6 +880,8 @@ create()
 
 enter()
 (
+    create_toolbox_container=false
+    prompt_for_create=true
     shell_to_exec=/bin/bash
 
     echo "$base_toolbox_command: checking if container $toolbox_container exists" >&3
@@ -887,10 +899,61 @@ enter()
             # shellcheck disable=SC2030
             toolbox_container="$toolbox_container_old"
         else
-            echo "$base_toolbox_command: container $toolbox_container not found" >&2
-            echo "Use the 'create' command to create a toolbox." >&2
-            echo "Try '$base_toolbox_command --help' for more information." >&2
-            exit 1
+            if ! containers=$(list_container_names); then
+                enter_print_container_not_found "$toolbox_container"
+                exit 1
+            fi
+
+            containers_count=$(echo "$containers" | grep --count . 2>&3)
+            if ! is_integer "$containers_count"; then
+                enter_print_container_not_found "$toolbox_container"
+                exit 1
+            fi
+
+            echo "$base_toolbox_command: found $containers_count containers" >&3
+
+            if [ "$containers_count" -eq 0 ] 2>&3; then
+                if $assume_yes; then
+                    create_toolbox_container=true
+                    prompt_for_create=false
+                fi
+
+                if $prompt_for_create; then
+                    prompt="No toolbox containers found. Create now? [y/N]"
+                    if ask_for_confirmation "n" "$prompt"; then
+                        create_toolbox_container=true
+                    else
+                        create_toolbox_container=false
+                    fi
+                fi
+
+                if ! $create_toolbox_container; then
+                    echo "A container can be created later with the 'create' command." >&2
+                    echo "Try '$base_toolbox_command --help' for more information." >&2
+                    exit 1
+                fi
+
+                if ! update_container_and_image_names; then
+                    exit 1
+                fi
+
+                if ! create true; then
+                    exit 1
+                fi
+            elif [ "$containers_count" -eq 1 ] 2>&3 \
+                 && [ "$toolbox_container" = "$toolbox_container_default" ] 2>&3; then
+                echo "$base_toolbox_command: container $toolbox_container not found" >&2
+
+                toolbox_container=$(echo "$containers" | grep . 2>&3 | head --lines 1 2>&3)
+                echo "Entering container $toolbox_container instead." >&2
+                echo "Use the 'create' command to create a different toolbox." >&2
+                echo "Try '$base_toolbox_command --help' for more information." >&2
+            else
+                echo "$base_toolbox_command: container $toolbox_container not found" >&2
+                echo "Use the '--container' option to select a toolbox." >&2
+                echo "Try '$base_toolbox_command --help' for more information." >&2
+                exit 1
+            fi
         fi
     fi
 


### PR DESCRIPTION
When there aren't any toolbox containers, 'toolbox enter' will offer to
create a new container, and if there's only one it will fallback to it.

https://github.com/debarshiray/toolbox/issues/128