### PR TITLE
Set TOOLBOX_CONTAINER in the environment to identify as a toolbox

### DIFF
--- a/profile.d/toolbox.sh
+++ b/profile.d/toolbox.sh
@@ -25,7 +25,7 @@ fi
 
 if [ -f /run/.containerenv ] \
    && ! [ -f "$toolbox_welcome_stub" ] \
-   && [ "$TOOLBOX_PATH" != "" ]; then
+   && [ "$TOOLBOX_CONTAINER" != "" ]; then
     echo ""
     echo "Welcome to the Toolbox; a container where you can install and run"
     echo "all your tools."

--- a/toolbox
+++ b/toolbox
@@ -834,6 +834,7 @@ create()
     # shellcheck disable=SC2086
     $prefix_sudo podman create \
             $toolbox_path_set \
+            --env TOOLBOX_CONTAINER="$toolbox_container" \
             --group-add wheel \
             --hostname toolbox \
             --name $toolbox_container \


### PR DESCRIPTION
This is a lot more clear and explicit than TOOLBOX_PATH, which is more
of an implementation detail to bind mount the toolbox script inside the
toolbox container.