### PR TITLE
Retain the PS1 across su(1) and sudo(8)

### DIFF
--- a/profile.d/toolbox.sh
+++ b/profile.d/toolbox.sh
@@ -24,23 +24,26 @@ if [ -f /run/ostree-booted ] \
 fi
 
 if [ -f /run/.containerenv ] \
-   && ! [ -f "$toolbox_welcome_stub" ] \
    && [ -f /run/.toolboxenv ]; then
-    echo ""
-    echo "Welcome to the Toolbox; a container where you can install and run"
-    echo "all your tools."
-    echo ""
-    echo " - Use DNF in the usual manner to install command line tools."
-    echo " - To create a new tools container, run 'toolbox create'."
-    echo ""
-    printf "For more information, see the "
-    # shellcheck disable=SC1003
-    printf '\033]8;;https://docs.fedoraproject.org/en-US/fedora-silverblue/toolbox/\033\\documentation\033]8;;\033\\'
-    printf ".\n"
-    echo ""
+    PS1="🔹[\u@\h \W]\\$ "
 
-    mkdir -p "$toolbox_config"
-    touch "$toolbox_welcome_stub"
+    if ! [ -f "$toolbox_welcome_stub" ]; then
+        echo ""
+        echo "Welcome to the Toolbox; a container where you can install and run"
+        echo "all your tools."
+        echo ""
+        echo " - Use DNF in the usual manner to install command line tools."
+        echo " - To create a new tools container, run 'toolbox create'."
+        echo ""
+        printf "For more information, see the "
+        # shellcheck disable=SC1003
+        printf '\033]8;;https://docs.fedoraproject.org/en-US/fedora-silverblue/toolbox/\033\\documentation\033]8;;\033\\'
+        printf ".\n"
+        echo ""
+
+        mkdir -p "$toolbox_config"
+        touch "$toolbox_welcome_stub"
+    fi
 fi
 
 unset toolbox_config

--- a/profile.d/toolbox.sh
+++ b/profile.d/toolbox.sh
@@ -25,7 +25,7 @@ fi
 
 if [ -f /run/.containerenv ] \
    && ! [ -f "$toolbox_welcome_stub" ] \
-   && [ "$TOOLBOX_CONTAINER" != "" ]; then
+   && [ -f /run/.toolboxenv ]; then
     echo ""
     echo "Welcome to the Toolbox; a container where you can install and run"
     echo "all your tools."

--- a/toolbox
+++ b/toolbox
@@ -374,6 +374,54 @@ container_name_is_valid()
 )
 
 
+copy_etc_profile_d_toolbox_to_container()
+(
+    container="$1"
+
+    if ! [ -f /etc/profile.d/toolbox.sh ] 2>&3; then
+        return 0
+    fi
+
+    # shellcheck disable=SC2174
+    if ! mkdir --mode 700 --parents "$XDG_RUNTIME_DIR"/toolbox 2>&3; then
+        echo "$base_toolbox_command: unable to copy /etc/profile.d/toolbox.sh: runtime directory not created" >&2
+        return 1
+    fi
+
+    exec 5>"$XDG_RUNTIME_DIR"/toolbox/profile.d-toolbox.lock
+    if ! flock 5 2>&3; then
+        echo "$base_toolbox_command: unable to copy /etc/profile.d/toolbox.sh: copy lock not acquired" >&2
+        return 1
+    fi
+
+    echo "$base_toolbox_command: looking for /etc/profile.d/toolbox.sh in container $toolbox_container" >&3
+
+    if $prefix_sudo podman exec \
+               "$container" \
+               sh -c 'mount | grep /etc/profile.d/toolbox.sh >/dev/null 2>/dev/null' 2>&3; then
+        echo "$base_toolbox_command: /etc/profile.d/toolbox.sh already mounted in container $toolbox_container" >&3
+        return 0
+    fi
+
+    echo "$base_toolbox_command: copying /etc/profile.d/toolbox.sh to container $toolbox_container" >&3
+
+    if ! $prefix_sudo podman cp /etc/profile.d/toolbox.sh "$toolbox_container":/etc/profile.d 2>&3; then
+        echo "$base_toolbox_command: unable to copy /etc/profile.d/toolbox.sh to container $toolbox_container" >&2
+        return 1
+    fi
+
+    if ! $prefix_sudo podman exec \
+                 --user root:root \
+                 "$toolbox_container" \
+                 chown root:root /etc/profile.d/toolbox.sh 2>&3; then
+        echo "$base_toolbox_command: unable to chown /etc/profile.d/toolbox.sh to container $toolbox_container" >&2
+        return 1
+    fi
+
+    return 0
+)
+
+
 create_enter_command()
 (
     container="$1"
@@ -1028,6 +1076,10 @@ enter()
 
     if ! $prefix_sudo podman start "$toolbox_container" >/dev/null 2>&3; then
         echo "$base_toolbox_command: failed to start container $toolbox_container" >&2
+        exit 1
+    fi
+
+    if ! copy_etc_profile_d_toolbox_to_container "$toolbox_container"; then
         exit 1
     fi
 

--- a/toolbox
+++ b/toolbox
@@ -66,7 +66,6 @@ toolbox_container_default=""
 toolbox_container_old=""
 toolbox_container_prefix_default=""
 toolbox_image=""
-toolbox_prompt="🔹[\u@\h \W]\\$ "
 user_id_real=$(id -ru 2>&3)
 verbose=false
 
@@ -1107,11 +1106,7 @@ enter()
             --interactive \
             --tty \
             "$toolbox_container" \
-            capsh --caps="" -- -c 'cd "$1"; export PS1="$2"; shift 2; exec "$@"' \
-                    /bin/sh \
-                    "$PWD" \
-                    "$toolbox_prompt" \
-                    "$shell_to_exec" -l 2>&3
+            capsh --caps="" -- -c 'cd "$1"; shift; exec "$@"' /bin/sh "$PWD" "$shell_to_exec" -l 2>&3
 )
 
 

--- a/toolbox
+++ b/toolbox
@@ -941,7 +941,6 @@ create()
     $prefix_sudo podman create \
             $dns_none \
             $toolbox_path_set \
-            --env TOOLBOX_CONTAINER="$toolbox_container" \
             --group-add wheel \
             --hostname toolbox \
             --name $toolbox_container \
@@ -1080,6 +1079,11 @@ enter()
     fi
 
     if ! copy_etc_profile_d_toolbox_to_container "$toolbox_container"; then
+        exit 1
+    fi
+
+    if ! $prefix_sudo podman exec --user root:root "$toolbox_container" touch /run/.toolboxenv 2>&3; then
+        echo "$base_toolbox_command: failed to create /run/.toolboxenv in container $toolbox_container" >&2
         exit 1
     fi
 


### PR DESCRIPTION
The shell start-up scripts are where the PS1 is meant to be set. So
far, the absence of a toolbox-specific start-up script was being worked
around by setting the PS1 as part of the 'podman exec' invocation. This
came with certain limitations. eg., using su(1) or sudo(8) to get a
root shell can overwrite the PS1 set during 'podman exec' with a value
set by the operating system's existing start-up scripts depending on
which environment variables were being retained.

Now that the toolbox has it's own /etc/profile.d/toolbox.sh start-up
script, it's time to move the PS1 to its rightful home.

Since the start-up script and /run/.toolboxenv are present in older
toolbox containers, this change should be fully backwards compatible
and lead to a more robust PS1 without breaking older containers.