### PR TITLE
Use a magenta hexagon instead of 🔹 in the PS1

### DIFF
--- a/profile.d/toolbox.sh
+++ b/profile.d/toolbox.sh
@@ -25,7 +25,7 @@ fi
 
 if [ -f /run/.containerenv ] \
    && [ -f /run/.toolboxenv ]; then
-    PS1="🔹[\u@\h \W]\\$ "
+    PS1=$(printf "\033[35m⬢\033[0m%s" "[\u@\h \W]\\$ ")
 
     if ! [ -f "$toolbox_welcome_stub" ]; then
         echo ""


### PR DESCRIPTION
... because of its likeness to the Toolbox logo. Note that the magenta
foreground colour is requested through a terminal escape sequence with
SGR parameters [1]. The specific colour code for magenta is 35.

[1] https://en.wikipedia.org/wiki/ANSI_escape_code