### PR TITLE
Reduce reliance on Buildah by switching to 'podman create --user ...'

### DIFF
--- a/toolbox
+++ b/toolbox
@@ -321,11 +321,6 @@ configure_working_container()
         return 1
     fi
 
-    if ! $prefix_sudo buildah config --user "$USER" "$working_container_name" >/dev/null 2>&3; then
-        echo "$base_toolbox_command: failed to configure the default user as $USER" >&2
-        return 1
-    fi
-
     if ! $prefix_sudo buildah config --workingdir "$HOME" "$working_container_name" >/dev/null 2>&3; then
         echo "$base_toolbox_command: failed to configure the initial working directory to $HOME" >&2
         return 1
@@ -951,6 +946,7 @@ create()
             --uidmap "$user_id_real":0:1 \
             --uidmap 0:1:"$user_id_real" \
             --uidmap "$uid_plus_one":"$uid_plus_one":"$max_minus_uid" \
+            --user "$USER" \
             $kcm_socket_bind \
             $toolbox_path_bind \
             $toolbox_profile_bind \


### PR DESCRIPTION
Currently, the toolbox script depends on both the buildah and podman
commands. However, both are Go programs, and like all Go programs the
absense of shared libraries leads to bigger binaries. eg., the buildah
and podman binaries are approximately 22 MB and 48 MB respectively,
whereas the flatpak binary is a mere 1.4 MB.

Due to this, there's some nascent desire from the Endless OS folks to
reduce the dependency footprint of the toolbox script by replacing
Buildah with the corresponding Podman commands. This is a step in that
direction.