### PR TITLE
Drop the Buildah dependency and the need for the user-specific customized image

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,20 +19,20 @@ works equally well if you're running e.g. existing Fedora Workstation or
 Server, and that's a useful way to incrementally adopt containerization.
 
 The toolbox environment is based on an [OCI](https://www.opencontainers.org/)
-image. On Fedora this is the `fedora-toolbox` image. This image is then
-customized for the current user to create a toolbox container that seamlessly
-integrates with the rest of the operating system.
+image. On Fedora this is the `fedora-toolbox` image. This image is used to
+create a toolbox container that seamlessly integrates with the rest of the
+operating system.
 
 ## Usage
 
 ### Create your toolbox container:
 ```
 [user@hostname ~]$ toolbox create
+Created container: fedora-toolbox-30
+Enter with: toolbox enter
 [user@hostname ~]$
 ```
-This will create a container, and an image, called
-`fedora-toolbox-<your-username>:<version-id>` that's specifically customised
-for your host user.
+This will create a container called `fedora-toolbox-<version-id>`.
 
 ### Enter the toolbox:
 ```

--- a/completion/bash/toolbox
+++ b/completion/bash/toolbox
@@ -13,12 +13,13 @@ __toolbox() {
   local MIN_VERSION=29
   local RAWHIDE_VERSION=31
 
-  local verbose_commands="create enter list run"
+  local verbose_commands="create enter init-container list run"
   local commands="$verbose_commands rm rmi"
 
   declare -A options
   local options=([create]="--candidate-registry --container --image --release" \
                  [enter]="--container --release" \
+                 [init-container]="--home --monitor-host --shell --uid --user" \
 		 [list]="--containers --images" \
 		 [rm]="--all --force" \
 		 [rmi]="--all --force" \

--- a/doc/meson.build
+++ b/doc/meson.build
@@ -8,6 +8,7 @@ manuals = [
   'toolbox.1',
   'toolbox-create.1',
   'toolbox-enter.1',
+  'toolbox-init-container.1',
   'toolbox-list.1',
   'toolbox-rm.1',
   'toolbox-rmi.1',

--- a/doc/toolbox-init-container.1.md
+++ b/doc/toolbox-init-container.1.md
@@ -1,0 +1,48 @@
+% toolbox-init-container(1)
+
+## NAME
+toolbox\-init\-container - Initialize a running container
+
+## SYNOPSIS
+**toolbox init-container** *--home HOME*
+                       *--monitor-host*
+                       *--shell SHELL*
+                       *--uid UID*
+                       *--user USER*
+
+## DESCRIPTION
+
+Initializes a newly created container that's running. It is primarily meant to
+be used as the entry point for all toolbox containers, and must be run inside
+the container that's to be initialized. It is not expected to be directly
+invoked by humans, and cannot be used on the host.
+
+## OPTIONS ##
+
+The following options are understood:
+
+**--home** HOME
+
+Create a user inside the toolbox container whose login directory is HOME.
+
+**--monitor-host**
+
+Ensure that certain configuration files inside the toolbox container are kept
+synchronized with their counterparts on the host. Currently, these files are
+`/etc/hosts` and `/etc/resolv.conf`.
+
+**--shell** SHELL
+
+Create a user inside the toolbox container whose login shell is SHELL.
+
+**--uid** UID
+
+Create a user inside the toolbox container whose numerical user ID is UID.
+
+**--user** USER
+
+Create a user inside the toolbox container whose login name is LOGIN.
+
+## SEE ALSO
+
+`podman(1)`, `podman-create(1)`, `podman-start(1)`

--- a/doc/toolbox.1.md
+++ b/doc/toolbox.1.md
@@ -57,6 +57,10 @@ Create a new toolbox container.
 
 Enter a toolbox container for interactive use.
 
+**toolbox-init-container(1)**
+
+Initialize a running container.
+
 **toolbox-list(1)**
 
 List existing toolbox containers and images.

--- a/toolbox
+++ b/toolbox
@@ -382,6 +382,7 @@ copy_etc_profile_d_toolbox_to_container()
     echo "$base_toolbox_command: looking for /etc/profile.d/toolbox.sh in container $toolbox_container" >&3
 
     if $prefix_sudo podman exec \
+               --user "$USER" \
                "$container" \
                sh -c 'mount | grep /etc/profile.d/toolbox.sh >/dev/null 2>/dev/null' 2>&3; then
         echo "$base_toolbox_command: /etc/profile.d/toolbox.sh already mounted in container $toolbox_container" >&3
@@ -936,7 +937,7 @@ create()
             --uidmap "$user_id_real":0:1 \
             --uidmap 0:1:"$user_id_real" \
             --uidmap "$uid_plus_one":"$uid_plus_one":"$max_minus_uid" \
-            --user "$USER" \
+            --user root:root \
             $kcm_socket_bind \
             $toolbox_path_bind \
             $toolbox_profile_bind \
@@ -1094,7 +1095,10 @@ run()
     echo "$base_toolbox_command: looking for $program in container $toolbox_container" >&3
 
     # shellcheck disable=SC2016
-    if ! $prefix_sudo podman exec "$toolbox_container" sh -c 'command -v "$1"' sh "$program" >/dev/null 2>&3; then
+    if ! $prefix_sudo podman exec \
+                 --user "$USER" \
+                 "$toolbox_container" \
+                 sh -c 'command -v "$1"' sh "$program" >/dev/null 2>&3; then
         if $fallback_to_bash; then
             echo "$base_toolbox_command: $program not found in $toolbox_container; using /bin/bash instead" >&3
             program=/bin/bash
@@ -1116,6 +1120,7 @@ run()
     $prefix_sudo podman exec \
             --interactive \
             --tty \
+            --user "$USER" \
             $set_environment \
             "$toolbox_container" \
             capsh --caps="" -- -c 'cd "$1"; shift; exec "$@"' /bin/sh "$PWD" "$program" "$@" 2>&3

--- a/toolbox
+++ b/toolbox
@@ -1598,11 +1598,6 @@ fi
 echo "$base_toolbox_command: resolved absolute path for $0 to $toolbox_command_path" >&3
 
 if [ -f /run/.containerenv ] 2>&3; then
-    if ! [ -f /run/.toolboxenv ] 2>&3; then
-        echo "$base_toolbox_command: this is not a toolbox container" >&2
-        exit 1
-    fi
-
     if [ "$TOOLBOX_PATH" = "" ] 2>&3; then
         echo "$base_toolbox_command: TOOLBOX_PATH not set" >&2
         exit 1
@@ -1633,6 +1628,11 @@ shift
 if [ -f /run/.containerenv ] 2>&3; then
     case $op in
         create | enter | list | rm | rmi | run )
+            if ! [ -f /run/.toolboxenv ] 2>&3; then
+                echo "$base_toolbox_command: this is not a toolbox container" >&2
+                exit 1
+            fi
+
             # shellcheck disable=SC2119
             forward_to_host
             exit "$?"

--- a/toolbox
+++ b/toolbox
@@ -925,6 +925,7 @@ create()
             $toolbox_path_set \
             --group-add wheel \
             --hostname toolbox \
+            --label "com.github.debarshiray.toolbox=true" \
             --name $toolbox_container \
             --network host \
             $no_hosts \

--- a/toolbox
+++ b/toolbox
@@ -450,12 +450,14 @@ create_environment_options()
 
 create_toolbox_container_name()
 (
-    basename=$(image_reference_get_basename "$toolbox_image")
+    image="$1"
+
+    basename=$(image_reference_get_basename "$image")
     if [ "$basename" = "" ] 2>&3; then
         return 100
     fi
 
-    tag=$(image_reference_get_tag "$toolbox_image")
+    tag=$(image_reference_get_tag "$image")
     if [ "$tag" = "" ] 2>&3; then
         return 101
     fi
@@ -1492,7 +1494,7 @@ update_container_and_image_names()
 
     # shellcheck disable=SC2031
     if [ "$toolbox_container" = "" ]; then
-        toolbox_container=$(create_toolbox_container_name)
+        toolbox_container=$(create_toolbox_container_name "$toolbox_image")
         if ! (
                  ret_val=$?
                  if [ "$ret_val" -ne 0 ] 2>&3; then

--- a/toolbox
+++ b/toolbox
@@ -1431,6 +1431,11 @@ exit_if_unrecognized_option()
 # shellcheck disable=SC2120
 forward_to_host()
 (
+    if ! command -v flatpak-spawn >/dev/null 2>&3; then
+        echo "$base_toolbox_command: flatpak-spawn not found" >&2
+        return 1
+    fi
+
     eval "set -- $arguments"
 
     set_environment=$(create_environment_options)
@@ -1443,6 +1448,9 @@ forward_to_host()
 
     # shellcheck disable=SC2086
     flatpak-spawn $set_environment --host "$TOOLBOX_PATH" "$@" 2>&3
+    ret_val="$?"
+
+    return "$ret_val"
 )
 
 
@@ -1592,11 +1600,6 @@ echo "$base_toolbox_command: resolved absolute path for $0 to $toolbox_command_p
 if [ -f /run/.containerenv ] 2>&3; then
     if ! [ -f /run/.toolboxenv ] 2>&3; then
         echo "$base_toolbox_command: this is not a toolbox container" >&2
-        exit 1
-    fi
-
-    if ! command -v flatpak-spawn >/dev/null 2>&3; then
-        echo "$base_toolbox_command: flatpak-spawn not found" >&2
         exit 1
     fi
 

--- a/toolbox
+++ b/toolbox
@@ -1627,203 +1627,193 @@ fi
 op=$1
 shift
 
-case $op in
-    create )
-        if [ -f /run/.containerenv ] 2>&3; then
+if [ -f /run/.containerenv ] 2>&3; then
+    case $op in
+        create | enter | list | rm | rmi | run )
             # shellcheck disable=SC2119
             forward_to_host
-        else
-            while has_prefix "$1" -; do
-                case $1 in
-                    --candidate-registry )
-                        registry=$registry_candidate
-                        ;;
-                    -c | --container )
-                        shift
-                        exit_if_missing_argument --container "$1"
-                        arg=$1
-                        if ! container_name_is_valid "$arg"; then
-                            echo "$base_toolbox_command: invalid argument for '--container'" >&2
-                            echo "Container names must match '$container_name_regexp'." >&2
-                            echo "Try '$base_toolbox_command --help' for more information." >&2
-                            exit 1
-                        fi
-                        toolbox_container="$arg"
-                        ;;
-                    -i | --image )
-                        shift
-                        exit_if_missing_argument --image "$1"
-                        base_toolbox_image=$1
-                        ;;
-                    -r | --release )
-                        shift
-                        exit_if_missing_argument --release "$1"
-                        arg=$(echo "$1" | sed "s/^F\|^f//" 2>&3)
-                        exit_if_non_positive_argument --release "$arg"
-                        release=$arg
-                        ;;
-                    * )
-                        exit_if_unrecognized_option "$1"
-                esac
-                shift
-            done
-            exit_if_extra_operand "$1"
-            if ! update_container_and_image_names; then
-                exit 1
-            fi
-            if ! create false; then
-                exit 1
-            fi
+            exit "$?"
+            ;;
+        * )
+           echo "$base_toolbox_command: unrecognized command '$op'" >&2
+           echo "Try '$base_toolbox_command --help' for more information." >&2
+           exit 1
+           ;;
+    esac
+fi
+
+case $op in
+    create )
+        while has_prefix "$1" -; do
+            case $1 in
+                --candidate-registry )
+                    registry=$registry_candidate
+                    ;;
+                -c | --container )
+                    shift
+                    exit_if_missing_argument --container "$1"
+                    arg=$1
+                    if ! container_name_is_valid "$arg"; then
+                        echo "$base_toolbox_command: invalid argument for '--container'" >&2
+                        echo "Container names must match '$container_name_regexp'." >&2
+                        echo "Try '$base_toolbox_command --help' for more information." >&2
+                        exit 1
+                    fi
+                    toolbox_container="$arg"
+                    ;;
+                -i | --image )
+                    shift
+                    exit_if_missing_argument --image "$1"
+                    base_toolbox_image=$1
+                    ;;
+                -r | --release )
+                    shift
+                    exit_if_missing_argument --release "$1"
+                    arg=$(echo "$1" | sed "s/^F\|^f//" 2>&3)
+                    exit_if_non_positive_argument --release "$arg"
+                    release=$arg
+                    ;;
+                * )
+                    exit_if_unrecognized_option "$1"
+            esac
+            shift
+        done
+        exit_if_extra_operand "$1"
+        if ! update_container_and_image_names; then
+            exit 1
+        fi
+        if ! create false; then
+            exit 1
         fi
         exit
         ;;
     enter )
-        if [ -f /run/.containerenv ] 2>&3; then
-            # shellcheck disable=SC2119
-            forward_to_host
-        else
-            while has_prefix "$1" -; do
-                case $1 in
-                    -c | --container )
-                        shift
-                        exit_if_missing_argument --container "$1"
-                        toolbox_container=$1
-                        ;;
-                    -r | --release )
-                        shift
-                        exit_if_missing_argument --release "$1"
-                        arg=$(echo "$1" | sed "s/^F\|^f//" 2>&3)
-                        exit_if_non_positive_argument --release "$arg"
-                        release=$arg
-                        ;;
-                    * )
-                        exit_if_unrecognized_option "$1"
-                esac
-                shift
-            done
-            exit_if_extra_operand "$1"
-            if ! update_container_and_image_names; then
-                exit 1
-            fi
-            enter
+        while has_prefix "$1" -; do
+            case $1 in
+                -c | --container )
+                    shift
+                    exit_if_missing_argument --container "$1"
+                    toolbox_container=$1
+                    ;;
+                -r | --release )
+                    shift
+                    exit_if_missing_argument --release "$1"
+                    arg=$(echo "$1" | sed "s/^F\|^f//" 2>&3)
+                    exit_if_non_positive_argument --release "$arg"
+                    release=$arg
+                    ;;
+                * )
+                    exit_if_unrecognized_option "$1"
+            esac
+            shift
+        done
+        exit_if_extra_operand "$1"
+        if ! update_container_and_image_names; then
+            exit 1
         fi
+        enter
         exit
         ;;
     list )
-        if [ -f /run/.containerenv ] 2>&3; then
-            # shellcheck disable=SC2119
-            forward_to_host
-        else
-            ls_images=false
-            ls_containers=false
-            while has_prefix "$1" -; do
-                case $1 in
-                    -c | --containers )
-                        ls_containers=true
-                        ;;
-                    -i | --images )
-                        ls_images=true
-                        ;;
-                    * )
-                        exit_if_unrecognized_option "$1"
-                esac
-                shift
-            done
-            exit_if_extra_operand "$1"
+        ls_images=false
+        ls_containers=false
+        while has_prefix "$1" -; do
+            case $1 in
+                -c | --containers )
+                    ls_containers=true
+                    ;;
+                -i | --images )
+                    ls_images=true
+                    ;;
+                * )
+                    exit_if_unrecognized_option "$1"
+            esac
+            shift
+        done
+        exit_if_extra_operand "$1"
 
-            if ! $ls_containers && ! $ls_images; then
-                ls_containers=true
-                ls_images=true
-            fi
-
-            if $ls_images; then
-                if ! images=$(list_images); then
-                    exit 1
-                fi
-            fi
-
-            if $ls_containers; then
-                if ! containers=$(list_containers); then
-                    exit 1
-                fi
-            fi
-
-            $ls_images && [ "$images" != "" ] && echo "$images"
-            $ls_containers && [ "$containers" != "" ] && echo "$containers"
+        if ! $ls_containers && ! $ls_images; then
+            ls_containers=true
+            ls_images=true
         fi
+
+        if $ls_images; then
+            if ! images=$(list_images); then
+                exit 1
+            fi
+        fi
+
+        if $ls_containers; then
+            if ! containers=$(list_containers); then
+                exit 1
+            fi
+        fi
+
+        $ls_images && [ "$images" != "" ] && echo "$images"
+        $ls_containers && [ "$containers" != "" ] && echo "$containers"
         exit
         ;;
     rm | rmi )
-        if [ -f /run/.containerenv ] 2>&3; then
-            # shellcheck disable=SC2119
-            forward_to_host
+        rm_all=false
+        rm_force=false
+        while has_prefix "$1" -; do
+            case $1 in
+                -a | --all )
+                    rm_all=true
+                    ;;
+                -f | --force )
+                    rm_force=true
+                    ;;
+                * )
+                    exit_if_unrecognized_option "$1"
+            esac
+            shift
+        done
+
+        rm_ids=""
+        if $rm_all; then
+            exit_if_extra_operand "$1"
         else
-            rm_all=false
-            rm_force=false
-            while has_prefix "$1" -; do
-                case $1 in
-                    -a | --all )
-                        rm_all=true
-                        ;;
-                    -f | --force )
-                        rm_force=true
-                        ;;
-                    * )
-                        exit_if_unrecognized_option "$1"
-                esac
+            exit_if_missing_argument "$op" "$1"
+            while [ "$1" != "" ]; do
+                rm_ids="$rm_ids $1"
                 shift
             done
+        fi
 
-            rm_ids=""
-            if $rm_all; then
-                exit_if_extra_operand "$1"
-            else
-                exit_if_missing_argument "$op" "$1"
-                while [ "$1" != "" ]; do
-                    rm_ids="$rm_ids $1"
-                    shift
-                done
-            fi
+        rm_ids=$(echo "$rm_ids" | sed "s/^ \+//" 2>&3)
 
-            rm_ids=$(echo "$rm_ids" | sed "s/^ \+//" 2>&3)
-
-            if [ "$op" = "rm" ]; then
-                remove_containers "$rm_ids" "$rm_all" "$rm_force"
-            else
-                remove_images "$rm_ids" "$rm_all" "$rm_force"
-            fi
+        if [ "$op" = "rm" ]; then
+            remove_containers "$rm_ids" "$rm_all" "$rm_force"
+        else
+            remove_images "$rm_ids" "$rm_all" "$rm_force"
         fi
         exit
         ;;
     run )
-        if [ -f /run/.containerenv ] 2>&3; then
-            # shellcheck disable=SC2119
-            forward_to_host
-        else
-            while has_prefix "$1" -; do
-                case $1 in
-                    -c | --container )
-                        shift
-                        exit_if_missing_argument --container "$1"
-                        toolbox_container=$1
-                        ;;
-                    -r | --release )
-                        shift
-                        exit_if_missing_argument --release "$1"
-                        arg=$(echo "$1" | sed "s/^F\|^f//" 2>&3)
-                        exit_if_non_positive_argument --release "$arg"
-                        release=$arg
-                        ;;
-                    * )
-                        exit_if_unrecognized_option "$1"
-                esac
-                shift
-            done
-            if ! update_container_and_image_names; then
-                exit 1
-            fi
-            run false true "$@"
+        while has_prefix "$1" -; do
+            case $1 in
+                -c | --container )
+                    shift
+                    exit_if_missing_argument --container "$1"
+                    toolbox_container=$1
+                    ;;
+                -r | --release )
+                    shift
+                    exit_if_missing_argument --release "$1"
+                    arg=$(echo "$1" | sed "s/^F\|^f//" 2>&3)
+                    exit_if_non_positive_argument --release "$arg"
+                    release=$arg
+                    ;;
+                * )
+                    exit_if_unrecognized_option "$1"
+            esac
+            shift
+        done
+        if ! update_container_and_image_names; then
+            exit 1
         fi
+        run false true "$@"
         exit
         ;;
     * )

--- a/toolbox
+++ b/toolbox
@@ -62,7 +62,8 @@ tab="$(printf '\t')"
 toolbox_command_path=""
 toolbox_container=""
 toolbox_container_default=""
-toolbox_container_old=""
+toolbox_container_old_v1=""
+toolbox_container_old_v2=""
 toolbox_container_prefix_default=""
 toolbox_image=""
 user_id_real=$(id -ru 2>&3)
@@ -230,123 +231,6 @@ ask_for_confirmation()
     done
 
     return "$ret_val"
-)
-
-
-check_image_for_volumes()
-(
-    image="$1"
-
-    echo "$base_toolbox_command: checking if image $image has volumes for host bind mounts" >&3
-
-    if volumes=$($prefix_sudo podman inspect \
-                         --format "{{.Config.Volumes}}" \
-                         --type image \
-                         "$image" 2>&3); then
-        if echo "$volumes" | grep "/dev/dri\|/dev/fuse" >/dev/null 2>&3; then
-            echo "$base_toolbox_command: image $image has volumes for host bind mounts:" >&3
-            echo "$base_toolbox_command: $volumes" >&3
-            echo "$base_toolbox_command: consider re-creating image $image" >&3
-        fi
-    fi
-)
-
-
-configure_working_container()
-(
-    working_container_name="$1"
-    podman_create_supports_dns_none_no_hosts="$2"
-
-    buildah_unshare_supports_sh_c=false
-
-    echo "$base_toolbox_command: checking if 'buildah unshare' supports sh -c" >&3
-
-    if $prefix_sudo buildah unshare -- sh -c 'echo "hello world"' >/dev/null 2>&3; then
-        echo "$base_toolbox_command: 'buildah unshare' supports sh -c" >&3
-        buildah_unshare_supports_sh_c=true
-    fi
-
-    if [ "$(readlink /home)" = var/home ] ; then
-        need_home_link=true
-    else
-        need_home_link=false
-    fi
-
-    if $need_home_link ; then
-        if ! $prefix_sudo buildah run "$working_container_name" -- \
-                     sh -c 'rmdir /home && mkdir -m 0755 -p /var/home && ln -s var/home /home' 2>&3; then
-            $prefix_sudo buildah rm "$working_container_name" >/dev/null 2>&3
-            echo "$base_toolbox_command: failed to make /home a symlink" >&2
-            return 1
-        fi
-    fi
-
-    if ! $prefix_sudo buildah copy "$working_container_name" \
-                 /etc/krb5.conf.d/kcm_default_ccache \
-                 /etc/krb5.conf.d >/dev/null 2>&3; then
-        $prefix_sudo buildah rm "$working_container_name" >/dev/null 2>&3
-        echo "$base_toolbox_command: failed to set KCM as the default Kerberos credential cache" >&2
-        return 1
-    fi
-
-    if ! $prefix_sudo buildah run "$working_container_name" -- useradd \
-                 --home-dir "$HOME" \
-                 --no-create-home \
-                 --shell "$SHELL" \
-                 --uid "$user_id_real" \
-                 --groups wheel \
-                 "$USER" \
-                 >/dev/null 2>&3; then
-        echo "$base_toolbox_command: failed to create user $USER with UID $user_id_real" >&2
-        return 1
-    fi
-
-    if ! $prefix_sudo buildah run "$working_container_name" -- passwd -d "$USER" >/dev/null 2>&3; then
-        echo "$base_toolbox_command: failed to remove password for user $USER" >&2
-        return 1
-    fi
-
-    if ! $prefix_sudo buildah run "$working_container_name" -- passwd -d root >/dev/null 2>&3; then
-        echo "$base_toolbox_command: failed to remove password for user root" >&2
-        return 1
-    fi
-
-    if ! $prefix_sudo buildah config \
-                 --label "com.github.debarshiray.toolbox=true" \
-                 "$working_container_name" >/dev/null 2>&3; then
-        echo "$base_toolbox_command: failed to add com.github.debarshiray.toolbox=true" >&2
-        return 1
-    fi
-
-    if $buildah_unshare_supports_sh_c && $podman_create_supports_dns_none_no_hosts; then
-        # shellcheck disable=SC2016
-        if ! $prefix_sudo buildah unshare --\
-                     sh -c 'working_container_root=$(buildah mount "$1") '\
-'                                   && cd "$working_container_root/etc" '\
-'                                   && unlink hosts '\
-'                                   && ln --symbolic /run/host/etc/hosts hosts '\
-'                                   && buildah umount "$1"' \
-                           "/bin/sh" \
-                           "$working_container_name" >/dev/null 2>&3; then
-            echo "$base_toolbox_command: failed to redirect /etc/hosts to /run/host/etc/hosts" >&2
-            return 1
-        fi
-
-        # shellcheck disable=SC2016
-        if ! $prefix_sudo buildah unshare -- \
-                     sh -c 'working_container_root=$(buildah mount "$1") '\
-'                                   && cd "$working_container_root/etc" '\
-'                                   && unlink resolv.conf '\
-'                                   && ln --symbolic /run/host/etc/resolv.conf resolv.conf '\
-'                                   && buildah umount "$1"' \
-                           "/bin/sh" \
-                           "$working_container_name" >/dev/null 2>&3; then
-            echo "$base_toolbox_command: failed to redirect /etc/resolv.conf to /run/host/etc/resolv.conf" >&2
-            return 1
-        fi
-    fi
-
-    return 0
 )
 
 
@@ -730,11 +614,10 @@ create()
     dns_none=""
     kcm_socket=""
     kcm_socket_bind=""
+    monitor_host=""
     no_hosts=""
-    podman_create_supports_dns_none_no_hosts=false
     tmpfs_size=$((64 * 1024 * 1024)) # 64 MiB
     toolbox_profile_bind=""
-    working_container_name="toolbox-working-container-$(uuidgen --time)"
 
     # shellcheck disable=SC2153
     if [ "$DBUS_SYSTEM_BUS_ADDRESS" != "" ]; then
@@ -778,111 +661,30 @@ create()
 
     if $prefix_sudo podman create --help 2>&3 | grep "hosts" >/dev/null 2>&3; then
         echo "$base_toolbox_command: 'podman create' supports --dns=none and --no-hosts" >&3
-        podman_create_supports_dns_none_no_hosts=true
+
         dns_none="--dns none"
         no_hosts="--no-hosts"
+
+        monitor_host="--monitor-host"
     fi
 
-    echo "$base_toolbox_command: checking if image $toolbox_image already exists" >&3
-
-    if ! $prefix_sudo podman image exists $toolbox_image >/dev/null 2>&3; then
-        if ! pull_base_toolbox_image; then
-            return 1
-        fi
-
-        if image_reference_has_domain "$base_toolbox_image"; then
-            base_toolbox_image_full="$base_toolbox_image"
-        else
-            if ! base_toolbox_image_full=$($prefix_sudo podman inspect \
-                                                   --format "{{index .RepoTags 0}}" \
-                                                   --type image \
-                                                   "$base_toolbox_image" 2>&3); then
-                echo "$base_toolbox_command: failed to get RepoTag for base image $base_toolbox_image" >&2
-                return 1
-            fi
-
-            echo "$base_toolbox_command: base image $base_toolbox_image resolved to $base_toolbox_image_full" >&3
-        fi
-
-        echo "$base_toolbox_command: trying to create working container $working_container_name" >&3
-
-        if spinner_directory=$(mktemp --directory --tmpdir $spinner_template 2>&3); then
-            spinner_message="$base_toolbox_command: creating working container: "
-            if ! spinner_start "$spinner_directory" "$spinner_message"; then
-                spinner_directory=""
-            fi
-        else
-            echo "$base_toolbox_command: unable to start spinner: spinner directory not created" >&2
-            spinner_directory=""
-        fi
-
-        $prefix_sudo buildah from --name "$working_container_name" "$base_toolbox_image_full" >/dev/null 2>&3
-        ret_val=$?
-
-        if [ "$spinner_directory" != "" ]; then
-            spinner_stop "$spinner_directory"
-        fi
-
-        if [ $ret_val -ne 0 ]; then
-            echo "$base_toolbox_command: failed to create working container" >&2
-            return 1
-        fi
-
-        echo "$base_toolbox_command: trying to configure working container $working_container_name" >&3
-
-        if spinner_directory=$(mktemp --directory --tmpdir $spinner_template 2>&3); then
-            spinner_message="$base_toolbox_command: configuring working container: "
-            if ! spinner_start "$spinner_directory" "$spinner_message"; then
-                spinner_directory=""
-            fi
-        else
-            echo "$base_toolbox_command: unable to start spinner: spinner directory not created" >&2
-            spinner_directory=""
-        fi
-
-        configure_working_container \
-                "$working_container_name" \
-                "$podman_create_supports_dns_none_no_hosts"
-        ret_val=$?
-
-        if [ "$spinner_directory" != "" ]; then
-            spinner_stop "$spinner_directory"
-        fi
-
-        if [ $ret_val -ne 0 ]; then
-            $prefix_sudo buildah rm "$working_container_name" >/dev/null 2>&3
-            return 1
-        fi
-
-        echo "$base_toolbox_command: trying to create image $toolbox_image" >&3
-
-        if spinner_directory=$(mktemp --directory --tmpdir $spinner_template 2>&3); then
-            spinner_message="$base_toolbox_command: creating image $toolbox_image: "
-            if ! spinner_start "$spinner_directory" "$spinner_message"; then
-                spinner_directory=""
-            fi
-        else
-            echo "$base_toolbox_command: unable to start spinner: spinner directory not created" >&2
-            spinner_directory=""
-        fi
-
-        $prefix_sudo buildah commit --rm "$working_container_name" "$toolbox_image" >/dev/null 2>&3
-        ret_val=$?
-
-        if [ "$spinner_directory" != "" ]; then
-            spinner_stop "$spinner_directory"
-        fi
-
-        if [ $ret_val -ne 0 ]; then
-            $prefix_sudo buildah rm "$working_container_name" >/dev/null 2>&3
-            echo "$base_toolbox_command: failed to create image $toolbox_image" >&2
-            return 1
-        fi
-
-        echo "$base_toolbox_command: created image $toolbox_image" >&3
+    if ! pull_base_toolbox_image; then
+        return 1
     fi
 
-    check_image_for_volumes "$toolbox_image"
+    if image_reference_has_domain "$base_toolbox_image"; then
+        base_toolbox_image_full="$base_toolbox_image"
+    else
+        if ! base_toolbox_image_full=$($prefix_sudo podman inspect \
+                                               --format "{{index .RepoTags 0}}" \
+                                               --type image \
+                                               "$base_toolbox_image" 2>&3); then
+            echo "$base_toolbox_command: failed to get RepoTag for base image $base_toolbox_image" >&2
+            return 1
+        fi
+
+        echo "$base_toolbox_command: base image $base_toolbox_image resolved to $base_toolbox_image_full" >&3
+    fi
 
     echo "$base_toolbox_command: checking if container $toolbox_container already exists" >&3
 
@@ -954,8 +756,13 @@ create()
             --volume /mnt:/mnt:rslave \
             --volume /run/media:/run/media:rslave \
             --workdir "$HOME" \
-            "$toolbox_image" \
-            sleep +Inf >/dev/null 2>&3
+            "$base_toolbox_image_full" \
+            toolbox init-container \
+                    --home "$HOME" \
+                    $monitor_host \
+                    --shell "$SHELL" \
+                    --uid "$user_id_real" \
+                    --user "$USER" >/dev/null 2>&3
     ret_val=$?
 
     if [ "$spinner_directory" != "" ]; then
@@ -982,6 +789,94 @@ enter()
 }
 
 
+init_container()
+{
+    init_container_home="$1"
+    init_container_monitor_host="$2"
+    init_container_shell="$3"
+    init_container_uid="$4"
+    init_container_user="$5"
+
+    if $init_container_monitor_host; then
+        working_directory="$PWD"
+
+        if ! readlink /etc/hosts >/dev/null 2>&3; then
+            if ! cd /etc 2>&3 && unlink hosts 2>&3 && ln --symbolic /run/host/etc/hosts hosts 2>&3; then
+                echo "$base_toolbox_command: failed to redirect /etc/hosts to /run/host/etc/hosts" >&2
+                return 1
+            fi
+        fi
+
+        if ! readlink /etc/resolv.conf >/dev/null 2>&3; then
+            if ! cd /etc 2>&3 \
+                 && unlink resolv.conf 2>&3 \
+                 && ln --symbolic /run/host/etc/resolv.conf resolv.conf 2>&3; then
+                echo "$base_toolbox_command: failed to redirect /etc/resolv.conf to /run/host/etc/resolv.conf" >&2
+                return 1
+            fi
+        fi
+
+        if ! cd "$working_directory" 2>&3; then
+            echo "$base_toolbox_command: failed to restore working directory" >&2
+        fi
+    fi
+
+    if ! id -u "$init_container_user" >/dev/null 2>&3; then
+        if [ "$(readlink /home)" = var/home ] 2>&3; then
+            # shellcheck disable=SC2174
+            if ! rmdir /home 2>&3 \
+                 && mkdir --mode 0755 --parents /var/home 2>&3 \
+                 && ln --symbolic var/home /home 2>&3; then
+                echo "$base_toolbox_command: failed to make /home a symlink" >&2
+                return 1
+            fi
+        fi
+
+        if ! useradd \
+                     --home-dir "$init_container_home" \
+                     --no-create-home \
+                     --shell "$init_container_shell" \
+                     --uid "$init_container_uid" \
+                     --groups wheel \
+                     "$init_container_user" >/dev/null 2>&3; then
+            echo "$base_toolbox_command: failed to add user $init_container_user with UID $init_container_uid" >&2
+            return 1
+        fi
+
+        if ! passwd --delete "$init_container_user" >/dev/null 2>&3; then
+            echo "$base_toolbox_command: failed to remove password for user $init_container_user" >&2
+            return 1
+        fi
+
+        if ! passwd --delete root >/dev/null 2>&3; then
+            echo "$base_toolbox_command: failed to remove password for user root" >&2
+            return 1
+        fi
+
+    fi
+
+    if ! [ -f /etc/krb5.conf.d/kcm_default_ccache ] 2>&3; then
+        cat <<EOF >/etc/krb5.conf.d/kcm_default_ccache 2>&3
+# Written by Toolbox
+# https://github.com/debarshiray/toolbox
+#
+# # To disable the KCM credential cache, comment out the following lines.
+
+[libdefaults]
+    default_ccache_name = KCM:
+EOF
+        ret_val=$?
+
+        if [ "$ret_val" -ne 0 ] 2>&3; then
+            echo "$base_toolbox_command: failed to set KCM as the default Kerberos credential cache" >&2
+            return 1
+        fi
+    fi
+
+    exec sleep +Inf
+}
+
+
 run()
 (
     fallback_to_bash="$1"
@@ -994,20 +889,19 @@ run()
 
     echo "$base_toolbox_command: checking if container $toolbox_container exists" >&3
 
-    if ! toolbox_image=$($prefix_sudo podman inspect \
-                                 --format "{{.ImageName}}" \
-                                 --type container \
-                                 $toolbox_container 2>&3); then
+    if ! $prefix_sudo podman container exists "$toolbox_container" 2>&3; then
         echo "$base_toolbox_command: container $toolbox_container not found" >&3
 
-        if toolbox_image=$($prefix_sudo podman inspect \
-                                   --format "{{.ImageName}}" \
-                                   --type container \
-                                   "$toolbox_container_old" 2>&3); then
-            echo "$base_toolbox_command: container $toolbox_container_old found" >&3
+        if $prefix_sudo podman container exists "$toolbox_container_old_v1" 2>&3; then
+            echo "$base_toolbox_command: container $toolbox_container_old_v1 found" >&3
 
             # shellcheck disable=SC2030
-            toolbox_container="$toolbox_container_old"
+            toolbox_container="$toolbox_container_old_v1"
+        elif $prefix_sudo podman container exists "$toolbox_container_old_v2" 2>&3; then
+            echo "$base_toolbox_command: container $toolbox_container_old_v2 found" >&3
+
+            # shellcheck disable=SC2030
+            toolbox_container="$toolbox_container_old_v2"
         else
             if $pedantic; then
                 enter_print_container_not_found "$toolbox_container"
@@ -1071,10 +965,6 @@ run()
             fi
         fi
     fi
-
-    echo "$base_toolbox_command: container $toolbox_container was created from image $toolbox_image" >&3
-
-    [ "$toolbox_image" != "" ] 2>&3 && check_image_for_volumes "$toolbox_image"
 
     echo "$base_toolbox_command: trying to start container $toolbox_container" >&3
 
@@ -1490,18 +1380,16 @@ update_container_and_image_names()
         return 1
     fi
 
-    echo "$base_toolbox_command: customized user-specific image is $toolbox_image" >&3
-
     # shellcheck disable=SC2031
     if [ "$toolbox_container" = "" ]; then
-        toolbox_container=$(create_toolbox_container_name "$toolbox_image")
+        toolbox_container=$(create_toolbox_container_name "$base_toolbox_image")
         if ! (
                  ret_val=$?
                  if [ "$ret_val" -ne 0 ] 2>&3; then
                      if [ "$ret_val" -eq 100 ] 2>&3; then
-                         echo "$base_toolbox_command: failed to get the basename of image $toolbox_image" >&2
+                         echo "$base_toolbox_command: failed to get the basename of image $base_toolbox_image" >&2
                      elif [ "$ret_val" -eq 101 ] 2>&3; then
-                         echo "$base_toolbox_command: failed to get the tag of image $toolbox_image" >&2
+                         echo "$base_toolbox_command: failed to get the tag of image $base_toolbox_image" >&2
                      else
                          echo "$base_toolbox_command: failed to create a name for the toolbox container" >&2
                      fi
@@ -1521,7 +1409,27 @@ update_container_and_image_names()
             return 1
         fi
 
-        toolbox_container_old="$toolbox_image"
+        toolbox_container_old_v1=$(create_toolbox_container_name "$toolbox_image")
+        if ! (
+                 ret_val=$?
+                 if [ "$ret_val" -ne 0 ] 2>&3; then
+                     if [ "$ret_val" -eq 100 ] 2>&3; then
+                         echo "$base_toolbox_command: failed to get the basename of image $toolbox_image" >&2
+                     elif [ "$ret_val" -eq 101 ] 2>&3; then
+                         echo "$base_toolbox_command: failed to get the tag of image $toolbox_image" >&2
+                     else
+                         echo "$base_toolbox_command: failed to create a name for the toolbox container" >&2
+                     fi
+
+                     exit 1
+                 fi
+
+                 exit 0
+            ); then
+            return 1
+        fi
+
+        toolbox_container_old_v2="$toolbox_image"
     fi
 
     echo "$base_toolbox_command: container is $toolbox_container" >&3
@@ -1541,6 +1449,13 @@ usage()
     echo "               [-y | --assumeyes]"
     echo "               enter [-c | --container <name>]"
     echo "                     [-r | --release <release>]"
+    echo "   or: toolbox [-v | --verbose]"
+    echo "               [-y | --assumeyes]"
+    echo "               init-container --home"
+    echo "                              --monitor-host"
+    echo "                              --shell"
+    echo "                              --uid"
+    echo "                              --user"
     echo "   or: toolbox [-v | --verbose]"
     echo "               [-y | --assumeyes]"
     echo "               list [-c | --containers]"
@@ -1567,7 +1482,7 @@ if [ "$host_id" = "fedora" ] 2>&3; then
 else
     release_default="29"
 fi
-toolbox_container_prefix_default="fedora-toolbox-$USER"
+toolbox_container_prefix_default="fedora-toolbox"
 toolbox_container_default="$toolbox_container_prefix_default-$release_default"
 
 while has_prefix "$1" -; do
@@ -1637,6 +1552,46 @@ if [ -f /run/.containerenv ] 2>&3; then
 
             # shellcheck disable=SC2119
             forward_to_host
+            exit "$?"
+            ;;
+        init-container )
+            init_container_monitor_host=false
+            while has_prefix "$1" -; do
+                case $1 in
+                    --home )
+                        shift
+                        exit_if_missing_argument --home "$1"
+                        init_container_home="$1"
+                        ;;
+                    --monitor-host )
+                        init_container_monitor_host=true
+                        ;;
+                    --shell )
+                        shift
+                        exit_if_missing_argument --shell "$1"
+                        init_container_shell="$1"
+                        ;;
+                    --uid )
+                        shift
+                        exit_if_missing_argument --uid "$1"
+                        init_container_uid="$1"
+                        ;;
+                    --user )
+                        shift
+                        exit_if_missing_argument --user "$1"
+                        init_container_user="$1"
+                        ;;
+                    * )
+                        exit_if_unrecognized_option "$1"
+                esac
+                shift
+            done
+            init_container \
+                    "$init_container_home" \
+                    "$init_container_monitor_host" \
+                    "$init_container_shell" \
+                    "$init_container_uid" \
+                    "$init_container_user"
             exit "$?"
             ;;
         * )
@@ -1718,6 +1673,11 @@ case $op in
         fi
         enter
         exit
+        ;;
+    init-container )
+        echo "$base_toolbox_command: The 'init-container' command can only be used inside containers" >&2
+        echo "Try '$base_toolbox_command --help' for more information." >&2
+        exit 1
         ;;
     list )
         ls_images=false

--- a/toolbox
+++ b/toolbox
@@ -994,12 +994,14 @@ run()
                                  --format "{{.ImageName}}" \
                                  --type container \
                                  $toolbox_container 2>&3); then
-        echo "$base_toolbox_command: checking if container $toolbox_container_old exists" >&3
+        echo "$base_toolbox_command: container $toolbox_container not found" >&3
 
         if toolbox_image=$($prefix_sudo podman inspect \
                                    --format "{{.ImageName}}" \
                                    --type container \
                                    "$toolbox_container_old" 2>&3); then
+            echo "$base_toolbox_command: container $toolbox_container_old found" >&3
+
             # shellcheck disable=SC2030
             toolbox_container="$toolbox_container_old"
         else


### PR DESCRIPTION
Currently, the toolbox script depends on both the buildah and podman commands. However, both are Go programs, and like all Go programs the absense of shared libraries leads to bigger binaries. eg., the buildah and podman binaries are approximately 22 MB and 48 MB respectively, whereas the flatpak binary is a mere 1.4 MB.

Due to this, there's some nascent desire from the Endless OS folks to reduce the dependency footprint of the toolbox script by dropping the Buildah dependency.

Tied to this is the use of the user-specific customized image. If nothing else, the purpose of this second image is hard to explain to users in Toolbox documentation. 

Secondly, since the configuration happens during the `toolbox create` command, backwards compatibility becomes difficult. Since these are pet containers, users are expected to use `create` only once. Therefore it's smart to make it more minimal and do more work in `enter`.

Both the above problems are solved by configuring the toolbox container after it has been created, instead of before. This can be done by making the toolbox script itself the entry point of the container, which can `exec sleep +Inf` once the initialization is done.

Based on an idea from Colin Walters.