### PR TITLE
Revert "Ensure that the toolbox user runs with 'wheel' as an ..."

### DIFF
--- a/toolbox
+++ b/toolbox
@@ -728,7 +728,6 @@ create()
     $prefix_sudo podman create \
             $dns_none \
             $toolbox_path_set \
-            --group-add wheel \
             --hostname toolbox \
             --label "com.github.debarshiray.toolbox=true" \
             --name $toolbox_container \


### PR DESCRIPTION
The --group-add option only affects the entry point of the toolbox
container.

This reverts commit 4bda42d4146f3d3baa8003428d1c0fa4b71239bd.