### PR TITLE
Unbreak the initialization of /etc/hosts and /etc/resolv.conf

### DIFF
--- a/toolbox
+++ b/toolbox
@@ -757,7 +757,7 @@ create()
             --volume /run/media:/run/media:rslave \
             --workdir "$HOME" \
             "$base_toolbox_image_full" \
-            toolbox init-container \
+            toolbox --verbose init-container \
                     --home "$HOME" \
                     $monitor_host \
                     --shell "$SHELL" \

--- a/toolbox
+++ b/toolbox
@@ -801,16 +801,16 @@ init_container()
         working_directory="$PWD"
 
         if ! readlink /etc/hosts >/dev/null 2>&3; then
-            if ! cd /etc 2>&3 && unlink hosts 2>&3 && ln --symbolic /run/host/etc/hosts hosts 2>&3; then
+            if ! (cd /etc 2>&3 && unlink hosts 2>&3 && ln --symbolic /run/host/etc/hosts hosts 2>&3); then
                 echo "$base_toolbox_command: failed to redirect /etc/hosts to /run/host/etc/hosts" >&2
                 return 1
             fi
         fi
 
         if ! readlink /etc/resolv.conf >/dev/null 2>&3; then
-            if ! cd /etc 2>&3 \
-                 && unlink resolv.conf 2>&3 \
-                 && ln --symbolic /run/host/etc/resolv.conf resolv.conf 2>&3; then
+            if ! (cd /etc 2>&3 \
+                  && unlink resolv.conf 2>&3 \
+                  && ln --symbolic /run/host/etc/resolv.conf resolv.conf 2>&3); then
                 echo "$base_toolbox_command: failed to redirect /etc/resolv.conf to /run/host/etc/resolv.conf" >&2
                 return 1
             fi


### PR DESCRIPTION
The unary logical negation operator (ie. !) was getting associated with
the 'cd /etc' instead of the entire sequence. As a result, neither
/etc/hosts nor /etc/resolv.conf were getting symlinked.

Fallout from 8b84b5e4604921fad818ede5267591de7f0993e6