### PR TITLE
Include container info in the container hostname

### DIFF
--- a/toolbox
+++ b/toolbox
@@ -746,12 +746,14 @@ create()
         spinner_directory=""
     fi
 
+    toolbox_hostname="$(hostname)::$toolbox_container::$base_toolbox_image"
+
     # shellcheck disable=SC2086
     $prefix_sudo podman create \
             $dns_none \
             $toolbox_path_set \
             --group-add "$group_for_sudo" \
-            --hostname toolbox \
+            --hostname $toolbox_hostname \
             --label "com.github.debarshiray.toolbox=true" \
             --name $toolbox_container \
             --network host \


### PR DESCRIPTION
This modifies the hostname of the container to now contain the hostname of the system it runs on along with the base image name. It takes the form of `localhost::container::imagename`, so an example would be `humboldt::test::fedora-toolbox:28`. 

Fixes #98.