### PR TITLE
Allow Qt applications to work without QT_X11_NO_MITSHM

### DIFF
--- a/toolbox
+++ b/toolbox
@@ -633,7 +633,6 @@ create()
     kcm_socket_bind=""
     monitor_host=""
     no_hosts=""
-    tmpfs_size=$((64 * 1024 * 1024)) # 64 MiB
     toolbox_profile_bind=""
 
     # shellcheck disable=SC2153
@@ -718,11 +717,6 @@ create()
         return 1
     fi
 
-    total_ram=$(awk '( $1 == "MemTotal:" ) { print $2 }' /proc/meminfo 2>&3) # kibibytes
-    if is_integer "$total_ram"; then
-        tmpfs_size=$((total_ram * 1024 / 2)) # bytes
-    fi
-
     toolbox_path_bind="--volume $TOOLBOX_PATH:/usr/bin/toolbox:ro"
     toolbox_path_set="--env TOOLBOX_PATH=$TOOLBOX_PATH"
 
@@ -752,6 +746,7 @@ create()
             $toolbox_path_set \
             --group-add "$group_for_sudo" \
             --hostname toolbox \
+            --ipc host \
             --label "com.github.debarshiray.toolbox=true" \
             --name $toolbox_container \
             --network host \
@@ -759,7 +754,6 @@ create()
             --pid host \
             --privileged \
             --security-opt label=disable \
-            --tmpfs /dev/shm:size="$tmpfs_size" \
             --uidmap "$user_id_real":0:1 \
             --uidmap 0:1:"$user_id_real" \
             --uidmap "$uid_plus_one":"$uid_plus_one":"$max_minus_uid" \


### PR DESCRIPTION
This reverts commit fdc00a2778afab061bf165429c4a3f3497dd091d.

https://github.com/debarshiray/toolbox/issues/163