### PR TITLE
Prevent Podman from complaining about 'podman cp --pause=true ...'

### DIFF
--- a/toolbox
+++ b/toolbox
@@ -275,7 +275,10 @@ copy_etc_profile_d_toolbox_to_container()
 
     echo "$base_toolbox_command: copying /etc/profile.d/toolbox.sh to container $toolbox_container" >&3
 
-    if ! $prefix_sudo podman cp /etc/profile.d/toolbox.sh "$toolbox_container":/etc/profile.d 2>&3; then
+    if ! $prefix_sudo podman cp \
+                 --pause=false \
+                 /etc/profile.d/toolbox.sh \
+                 "$toolbox_container":/etc/profile.d 2>&3; then
         echo "$base_toolbox_command: unable to copy /etc/profile.d/toolbox.sh to container $toolbox_container" >&2
         return 1
     fi


### PR DESCRIPTION
Rootless containers cannot be paused while data is copied into them.
The '--pause' flag used to default to 'true', but it would be silently
ignored until recently [1,2] when it got turned into an error in
podman-1.4.0. Therefore, it has to be explicitly toggled using
'--pause=false'. Otherwise, it would lead to:
  toolbox: copying /etc/profile.d/toolbox.sh to container fubar
  Error: cannot copy into running rootless container with pause set -
    pass --pause=false to force copying
  toolbox: unable to copy /etc/profile.d/toolbox.sh to container fubar

The '--pause' flag was latter changed to default to 'false' [3], but
it's good to be defensive and have this addressed from both sides.

Note that 'podman cp --pause false ...' doesn't work. It's necessary to
use the '=' because it gets confused trying to parse the
space-separated source and destination path arguments.

[1] Podman commit 48e35f7da70c24ed
    https://github.com/containers/libpod/commit/48e35f7da70c24ed

[2] Podman commit 57d40939792719e6
    https://github.com/containers/libpod/commit/57d40939792719e6

[3] Podman commit d40b450afdc9784a
    https://github.com/containers/libpod/commit/d40b450afdc9784a