### PR TITLE
Fix PS1 line wrapping

### DIFF
--- a/profile.d/toolbox.sh
+++ b/profile.d/toolbox.sh
@@ -25,7 +25,7 @@ fi
 
 if [ -f /run/.containerenv ] \
    && [ -f /run/.toolboxenv ]; then
-    PS1=$(printf "\033[35m⬢\033[0m%s" "[\u@\h \W]\\$ ")
+    PS1=$(printf "\[\033[35m\]⬢\[\033[0m\]%s" "[\u@\h \W]\\$ ")
 
     if ! [ -f "$toolbox_welcome_stub" ]; then
         echo ""


### PR DESCRIPTION
Enclose non-printable sequences in the `PS1` with `\[\]` so its length gets calculated properly. Fixes #190. 