### PR TITLE
Update toolbox help screen

### DIFF
--- a/completion/bash/toolbox
+++ b/completion/bash/toolbox
@@ -13,12 +13,13 @@ __toolbox() {
   local MIN_VERSION=29
   local RAWHIDE_VERSION=31
 
-  local verbose_commands="create enter init-container list run"
+  local verbose_commands="create enter help init-container list run"
   local commands="$verbose_commands rm rmi"
 
   declare -A options
   local options=([create]="--candidate-registry --container --image --release" \
                  [enter]="--container --release" \
+                 [help]="$commands" \
                  [init-container]="--home --home-link --monitor-host --shell --uid --user" \
 		 [list]="--containers --images" \
 		 [rm]="--all --force" \

--- a/doc/meson.build
+++ b/doc/meson.build
@@ -9,6 +9,7 @@ manuals = [
   'toolbox-create.1',
   'toolbox-enter.1',
   'toolbox-init-container.1',
+  'toolbox-help.1',
   'toolbox-list.1',
   'toolbox-rm.1',
   'toolbox-rmi.1',

--- a/doc/toolbox-help.1.md
+++ b/doc/toolbox-help.1.md
@@ -1,0 +1,31 @@
+% toolbox-help(1)
+
+## NAME
+toolbox\-help - Display help information about Toolbox
+
+## SYNOPSIS
+**toolbox help** [*COMMAND*]
+
+## DESCRIPTION
+
+When no COMMAND is specified, the `toolbox(1)` manual is shown. If a COMMAND
+is specified, a manual page for that command is brought up.
+
+Note that `toolbox --help ...` is identical to `toolbox help ...` because the
+former is internally converted to the latter.
+
+This page can be displayed with `toolbox help help` or `toolbox help --help`.
+
+## EXAMPLES
+
+### Show the toolbox manual
+
+```
+$ toolbox help
+```
+
+### Show the manual for the create command
+
+```
+$ toolbox help create
+```

--- a/doc/toolbox.1.md
+++ b/doc/toolbox.1.md
@@ -56,6 +56,10 @@ Create a new toolbox container.
 
 Enter a toolbox container for interactive use.
 
+**toolbox-help(1)**
+
+Display help information about Toolbox.
+
 **toolbox-init-container(1)**
 
 Initialize a running container.

--- a/doc/toolbox.1.md
+++ b/doc/toolbox.1.md
@@ -42,8 +42,7 @@ Print a synopsis of this manual and exit.
 
 **--verbose, -v**
 
-Print debug information. This includes messages coming from the standard error
-stream of internal commands.
+Print debug information including standard error stream of internal commands.
 
 ## COMMANDS
 

--- a/toolbox
+++ b/toolbox
@@ -1189,6 +1189,18 @@ run()
 )
 
 
+help()
+(
+    to_help_command="$1"
+
+    if [ "$to_help_command" = "" ] 2>&3 || [ "$to_help_command" = "$base_toolbox_command" ] 2>&3; then
+        exec man toolbox 2>&1
+    fi
+
+    exec man toolbox-"$to_help_command" 2>&1
+)
+
+
 list_images()
 (
     output=""
@@ -1677,44 +1689,6 @@ update_container_and_image_names()
 }
 
 
-usage()
-{
-    echo "Usage: toolbox [-v | --verbose]"
-    echo "               [-y | --assumeyes]"
-    echo "               create [--candidate-registry]"
-    echo "                      [-c | --container <name>]"
-    echo "                      [-i | --image <name>]"
-    echo "                      [-r | --release <release>]"
-    echo "   or: toolbox [-v | --verbose]"
-    echo "               [-y | --assumeyes]"
-    echo "               enter [-c | --container <name>]"
-    echo "                     [-r | --release <release>]"
-    echo "   or: toolbox [-v | --verbose]"
-    echo "               [-y | --assumeyes]"
-    echo "               init-container --home"
-    echo "                              --home-link"
-    echo "                              --monitor-host"
-    echo "                              --shell"
-    echo "                              --uid"
-    echo "                              --user"
-    echo "   or: toolbox [-v | --verbose]"
-    echo "               [-y | --assumeyes]"
-    echo "               list [-c | --containers]"
-    echo "                    [-i | --images]"
-    echo "   or: toolbox [-y | --assumeyes]"
-    echo "               rm [-a | --all]"
-    echo "                  [-f | --force] [<container> ...]"
-    echo "   or: toolbox [-y | --assumeyes]"
-    echo "               rmi [-a | --all]"
-    echo "                   [-f | --force] [<image> ...]"
-    echo "   or: toolbox [-v | --verbose]"
-    echo "               [-y | --assumeyes]"
-    echo "               run [-c | --container <name>]"
-    echo "                   [-r | --release <release>] <command>"
-    echo "   or: toolbox --help"
-}
-
-
 arguments=$(save_positional_parameters "$@")
 
 host_id=$(get_host_id)
@@ -1732,7 +1706,18 @@ while has_prefix "$1" -; do
             assume_yes=true
             ;;
         -h | --help )
-            usage
+            if [ -f /run/.containerenv ] 2>&3; then
+                if ! [ -f /run/.toolboxenv ] 2>&3; then
+                    echo "$base_toolbox_command: this is not a toolbox container" >&2
+                    exit 1
+                fi
+
+                # shellcheck disable=SC2119
+                forward_to_host
+                exit
+            fi
+
+            help "$2"
             exit
             ;;
         --sudo )
@@ -1794,7 +1779,7 @@ shift
 
 if [ -f /run/.containerenv ] 2>&3; then
     case $op in
-        create | enter | list | rm | rmi | run )
+        create | enter | list | rm | rmi | run | help )
             if ! [ -f /run/.toolboxenv ] 2>&3; then
                 echo "$base_toolbox_command: this is not a toolbox container" >&2
                 exit 1
@@ -1809,6 +1794,11 @@ if [ -f /run/.containerenv ] 2>&3; then
             init_container_monitor_host=false
             while has_prefix "$1" -; do
                 case $1 in
+                    -h | --help )
+                        # shellcheck disable=SC2119
+                        forward_to_host
+                        exit
+                        ;;
                     --home )
                         shift
                         exit_if_missing_argument --home "$1"
@@ -1880,6 +1870,10 @@ case $op in
                     fi
                     toolbox_container="$arg"
                     ;;
+                -h | --help )
+                    help "$op"
+                    exit
+                    ;;
                 -i | --image )
                     shift
                     exit_if_missing_argument --image "$1"
@@ -1914,6 +1908,10 @@ case $op in
                     exit_if_missing_argument --container "$1"
                     toolbox_container=$1
                     ;;
+                -h | --help )
+                    help "$op"
+                    exit
+                    ;;
                 -r | --release )
                     shift
                     exit_if_missing_argument --release "$1"
@@ -1933,7 +1931,30 @@ case $op in
         enter
         exit
         ;;
+    help )
+        while has_prefix "$1" -; do
+            case $1 in
+                -h | --help )
+                    help "$op"
+                    exit
+                    ;;
+                * )
+                    exit_if_unrecognized_option "$1"
+            esac
+            shift
+        done
+        help "$1"
+        exit
+        ;;
     init-container )
+        while has_prefix "$1" -; do
+            case $1 in
+                -h | --help )
+                    help "$op"
+                    exit
+            esac
+            shift
+        done
         echo "$base_toolbox_command: The 'init-container' command can only be used inside containers" >&2
         echo "Try '$base_toolbox_command --help' for more information." >&2
         exit 1
@@ -1945,6 +1966,10 @@ case $op in
             case $1 in
                 -c | --containers )
                     ls_containers=true
+                    ;;
+                -h | --help )
+                    help "$op"
+                    exit
                     ;;
                 -i | --images )
                     ls_images=true
@@ -1988,6 +2013,10 @@ case $op in
                 -f | --force )
                     rm_force=true
                     ;;
+                -h | --help )
+                    help "$op"
+                    exit
+                    ;;
                 * )
                     exit_if_unrecognized_option "$1"
             esac
@@ -2021,6 +2050,10 @@ case $op in
                     shift
                     exit_if_missing_argument --container "$1"
                     toolbox_container=$1
+                    ;;
+                -h | --help )
+                    help "$op"
+                    exit
                     ;;
                 -r | --release )
                     shift


### PR DESCRIPTION
Hi, I recently started to experiment with Fedora Silverblue and naturally with toolbox and during it's usage I found the help screen to be a bit confusing and too verbose. So I took inspiration from other projects and reorganized it a little bit.

Current help screen:
![Screenshot from 2019-06-20 17-49-16](https://user-images.githubusercontent.com/17991284/59863057-4559f400-9384-11e9-8fb6-169f2f394f17.png)

Help screen with update:
![Screenshot from 2019-06-20 17-48-51](https://user-images.githubusercontent.com/17991284/59863063-48ed7b00-9384-11e9-932b-ddbb5d620ecc.png)
