### PR TITLE
Create /run/.toolboxenv inside the toolbox container's entry point too

### DIFF
--- a/toolbox
+++ b/toolbox
@@ -865,6 +865,11 @@ init_container()
     init_container_uid="$5"
     init_container_user="$6"
 
+    if ! touch /run/.toolboxenv 2>&3; then
+        echo "$base_toolbox_command: failed to create /run/.toolboxenv" >&2
+        return 1
+    fi
+
     if $init_container_monitor_host; then
         working_directory="$PWD"
 


### PR DESCRIPTION
Creating /run/.toolboxenv in run(), outside the entry point, has the
advantage of automatically working with older toolbox containers.
However, at some point those containers are going to get end-of-lifed.
Then it would be nice to have this bit of initialization tucked away
inside the entry point.