### PR TITLE
Adjust the grep match pattern to be more specific

### DIFF
--- a/toolbox
+++ b/toolbox
@@ -1799,7 +1799,7 @@ if [ -f /run/.containerenv ] 2>&3; then
 else
     echo "$base_toolbox_command: checking if /etc/subgid and /etc/subuid have entries for user $USER" >&3
 
-    if ! grep "$USER" /etc/subgid >/dev/null 2>&3 || ! grep "$USER" /etc/subuid >/dev/null 2>&3; then
+    if ! grep "^$USER:" /etc/subgid >/dev/null 2>&3 || ! grep "^$USER:" /etc/subuid >/dev/null 2>&3; then
         echo "$base_toolbox_command: /etc/subgid and /etc/subuid don't have entries for user $USER" >&2
         echo "See the podman(1), subgid(5), subuid(5) and usermod(8) manuals for more" >&2
         echo "information." >&2


### PR DESCRIPTION
Adjust the grep match pattern to be more specific.
Here is an example that shows the difference:

    $ export USER=foo
    $ echo -e "foo:100000:65536\nfoobar:165536:65536" 
    foo:100000:65536
    foobar:165536:65536
    $ echo -e "foo:100000:65536\nfoobar:165536:65536" | grep "$USER"
    foo:100000:65536
    foobar:165536:65536 
    $ echo -e "foo:100000:65536\nfoobar:165536:65536" | grep "^$USER:"
    foo:100000:65536
    $


Signed-off-by: Erik Sjölund <erik.sjolund@gmail.com>