### PR TITLE
Fix copying profile.d/toolbox.sh to container

### DIFF
--- a/toolbox
+++ b/toolbox
@@ -534,10 +534,11 @@ is_etc_profile_d_toolbox_a_bind_mount()
 {
     container="$1"
 
-    $prefix_sudo podman inspect --format "[{{range .Mounts}}{{.Dst}} {{end}}]" --type container "$container" 2>&3 \
-    | grep /etc/profile.d/toolbox.sh >/dev/null 2>/dev/null 2>&3
-
-    return "$?"
+    $prefix_sudo podman exec \
+            --user "$USER" \
+            "$container" \
+            sh -c 'mount | grep /etc/profile.d/toolbox.sh >/dev/null 2>/dev/null' 2>&3
+    return $?
 }
 
 

--- a/toolbox
+++ b/toolbox
@@ -1117,28 +1117,35 @@ run()
 
     echo "$base_toolbox_command: starting container $toolbox_container" >&3
 
+    echo "$base_toolbox_command: checking if /etc/profile.d/toolbox.sh is mounted in container $toolbox_container." >&3
+
     if is_etc_profile_d_toolbox_a_bind_mount "$toolbox_container"; then
-        echo "$base_toolbox_command: /etc/profile.d/toolbox.sh already mounted in container $toolbox_container" >&3
+        echo "$base_toolbox_command: /etc/profile.d/toolbox.sh is mounted in container $toolbox_container. Umounting to ensure correct version is used." >&3
+
+        if ! $prefix_sudo podman exec --user root:root "$toolbox_container" umount /etc/profile.d/toolbox.sh 2>&3; then
+            echo "$base_toolbox_command: failed to umount /etc/profile.d/toolbox.sh inside container" >&2
+            exit 1
+        fi
 
         if ! $prefix_sudo podman start "$toolbox_container" >/dev/null 2>&3; then
             echo "$base_toolbox_command: failed to start container $toolbox_container" >&2
             exit 1
         fi
     else
-        echo "$base_toolbox_command: /etc/profile.d/toolbox.sh not mounted in container $toolbox_container" >&3
+        echo "$base_toolbox_command: /etc/profile.d/toolbox.sh is not mounted in container $toolbox_container" >&3
+    fi
 
-        if ! copy_etc_profile_d_toolbox_to_runtime_directory; then
-            exit 1
-        fi
+    if ! copy_etc_profile_d_toolbox_to_runtime_directory; then
+        exit 1
+    fi
 
-        if ! $prefix_sudo podman start "$toolbox_container" >/dev/null 2>&3; then
-            echo "$base_toolbox_command: failed to start container $toolbox_container" >&2
-            exit 1
-        fi
+    if ! $prefix_sudo podman start "$toolbox_container" >/dev/null 2>&3; then
+        echo "$base_toolbox_command: failed to start container $toolbox_container" >&2
+        exit 1
+    fi
 
-        if ! copy_etc_profile_d_toolbox_to_container "$toolbox_container"; then
-            exit 1
-        fi
+    if ! copy_etc_profile_d_toolbox_to_container "$toolbox_container"; then
+        exit 1
     fi
 
     if ! $prefix_sudo podman exec --user root:root "$toolbox_container" touch /run/.toolboxenv 2>&3; then


### PR DESCRIPTION
This fixes a couple of issues I am running with latest master (one of which also applies to 0.0.11) and podman 1.2.0 on containers created with toolbox 0.0.10.