### PR TITLE
profile.d: make silverblue check more specific

### DIFF
--- a/profile.d/toolbox.sh
+++ b/profile.d/toolbox.sh
@@ -5,8 +5,13 @@ toolbox_config="$HOME/.config/toolbox"
 host_welcome_stub="$toolbox_config/host-welcome-shown"
 toolbox_welcome_stub="$toolbox_config/toolbox-welcome-shown"
 
+# shellcheck disable=SC1091
+. /usr/lib/os-release
+
 if [ -f /run/ostree-booted ] \
-   && ! [ -f "$host_welcome_stub" ]; then
+   && ! [ -f "$host_welcome_stub" ] \
+   && [ "${ID}" = "fedora" ] \
+   && { [ "${VARIANT_ID}" = "workstation" ] || [ "${VARIANT_ID}" = "silverblue" ]; }; then
     echo ""
     echo "Welcome to Fedora Silverblue. This terminal is running on the"
     echo "host system. You may want to try out the Toolbox for a directly"


### PR DESCRIPTION
The Silverblue welcome message was being displayed incorrectly on
other ostree based OS's (Fedora Atomic Host, Fedora CoreOS).
Silverblue is the only one that runs a desktop so the gdm check
was used to distinguish between the other Fedora variants.