### PR TITLE
Try to unbreak the terminal size when working nested

### DIFF
--- a/toolbox
+++ b/toolbox
@@ -338,8 +338,6 @@ create_environment_options()
             echo "$base_toolbox_command: failed to parse the number of lines from the terminal size" >&3
             lines=""
         fi
-
-        environment_options="$environment_options --env=COLUMNS=$columns --env=LINES=$lines"
     else
         echo "$base_toolbox_command: failed to read terminal size" >&3
     fi

--- a/toolbox
+++ b/toolbox
@@ -29,11 +29,13 @@ container_name_regexp="[a-zA-Z0-9][a-zA-Z0-9_.-]*"
 
 environment=$(set)
 environment_variables="COLORTERM \
+        COLUMNS \
         DBUS_SESSION_BUS_ADDRESS \
         DBUS_SYSTEM_BUS_ADDRESS \
         DESKTOP_SESSION \
         DISPLAY \
         LANG \
+        LINES \
         SHELL \
         SSH_AUTH_SOCK \
         TERM \
@@ -358,11 +360,11 @@ create_environment_options()
                   fi
               done
 
-              if [ "$columns" != "" ] 2>&3; then
+              if ! (echo "$environment_options" | grep COLUMNS >/dev/null 2>&3) && [ "$columns" != "" ] 2>&3; then
                   environment_options="$environment_options --env=COLUMNS=$columns"
               fi
 
-              if [ "$lines" != "" ] 2>&3; then
+              if ! (echo "$environment_options" | grep LINES >/dev/null 2>&3) && [ "$lines" != "" ] 2>&3; then
                   environment_options="$environment_options --env=LINES=$lines"
               fi
 


### PR DESCRIPTION
When running nested, stty(1) is invoked against the inner
pseudo-terminal pair created by 'podman exec --tty' which may not have
a valid size due to: https://github.com/containers/libpod/issues/3946

In such cases, the COLUMNS and LINES variables set by toolbox(1) in the
outer environment should be forwarded.

This should have been part of commit 05544fb2714ec096.

https://github.com/debarshiray/toolbox/issues/242