### PR TITLE
Give access to the system Flatpak directory

### DIFF
--- a/toolbox
+++ b/toolbox
@@ -685,6 +685,7 @@ create()
     dbus_system_bus_address="unix:path=/var/run/dbus/system_bus_socket"
     dns_none=""
     home_link=""
+    flatpak_system_directory_bind=""
     kcm_socket=""
     kcm_socket_bind=""
     monitor_host=""
@@ -697,6 +698,10 @@ create()
     fi
     dbus_system_bus_path=$(echo "$dbus_system_bus_address" | cut --delimiter = --fields 2 2>&3)
     dbus_system_bus_path=$(readlink --canonicalize "$dbus_system_bus_path" 2>&3)
+
+    if [ -d /var/lib/flatpak ] 2>&3; then
+        flatpak_system_directory_bind="--volume /var/lib/flatpak:/var/lib/flatpak:ro"
+    fi
 
     # Note that 'systemctl show ...' doesn't terminate with a non-zero exit
     # code when used with an unknown unit. eg.:
@@ -833,6 +838,7 @@ create()
             --security-opt label=disable \
             --userns=keep-id \
             --user root:root \
+            $flatpak_system_directory_bind \
             $kcm_socket_bind \
             $toolbox_path_bind \
             $toolbox_profile_bind \


### PR DESCRIPTION
This is helpful when running a development build of GNOME Shell from
within a toolbox container. It enables populating the application grid
with Flatpak applications installed system-wide on the host.