### PR TITLE
Don't exit with a non-zero code from 'toolbox list -i'

### DIFF
--- a/toolbox
+++ b/toolbox
@@ -2034,8 +2034,14 @@ case $op in
             fi
         fi
 
-        $ls_images && [ "$images" != "" ] 2>&3 && echo "$images"
-        $ls_containers && [ "$containers" != "" ] 2>&3 && echo "$containers"
+        if $ls_images && [ "$images" != "" ] 2>&3; then
+            echo "$images"
+        fi
+
+        if $ls_containers && [ "$containers" != "" ] 2>&3; then
+            echo "$containers"
+        fi
+
         exit
         ;;
     rm | rmi )

--- a/toolbox
+++ b/toolbox
@@ -2034,8 +2034,8 @@ case $op in
             fi
         fi
 
-        $ls_images && [ "$images" != "" ] && echo "$images"
-        $ls_containers && [ "$containers" != "" ] && echo "$containers"
+        $ls_images && [ "$images" != "" ] 2>&3 && echo "$images"
+        $ls_containers && [ "$containers" != "" ] 2>&3 && echo "$containers"
         exit
         ;;
     rm | rmi )


### PR DESCRIPTION
When listing only images, 'exit' was picking up the non-zero exit code
from the following (failing) statement meant for containers. An
explicit 'if' branch prevents the exit code of the condition from
leaking out.

Fallout from 5e4e63a11b21de97be65c4c7ec4a62c943084287