### PR TITLE
Expose a few more host locations inside the container under /run/host

### DIFF
--- a/toolbox
+++ b/toolbox
@@ -872,6 +872,10 @@ create()
             --volume /dev:/dev:rslave \
             --volume /media:/media:rslave \
             --volume /mnt:/mnt:rslave \
+            --volume /run:/run/host/run:rslave \
+            --volume /tmp:/run/host/tmp:rslave \
+            --volume /usr:/run/host/usr:rslave \
+            --volume /var:/run/host/var:rslave \
             "$base_toolbox_image_full" \
             toolbox --verbose init-container \
                     --home "$HOME" \


### PR DESCRIPTION
This is meant to alleviate some of the pain of not being able to modify
the list of bind mounts once a toolbox container has been created. For
some cases, where read-only access is enough, one can get by with
setting up symbolic links inside the toolbox container.

Based on an idea from Colin Walters.