### PR TITLE
Switch to using /usr/lib/os-release instead of /etc/os-release

### DIFF
--- a/toolbox
+++ b/toolbox
@@ -457,7 +457,7 @@ get_group_for_sudo()
 get_host_id()
 (
     # shellcheck disable=SC1091
-    . /etc/os-release
+    . /usr/lib/os-release
     echo "$ID"
 )
 
@@ -465,7 +465,7 @@ get_host_id()
 get_host_version_id()
 (
     # shellcheck disable=SC1091
-    . /etc/os-release
+    . /usr/lib/os-release
     echo "$VERSION_ID"
 )
 


### PR DESCRIPTION
On systemd-based systems /etc/os-release is a symbolic link to
/usr/lib/os-release. So this avoids one extra lookup.