### PR TITLE
Let the terminal know the active container only on some Fedora variants

### DIFF
--- a/toolbox
+++ b/toolbox
@@ -462,6 +462,14 @@ get_host_id()
 )
 
 
+get_host_variant_id()
+(
+    # shellcheck disable=SC1091
+    . /usr/lib/os-release
+    echo "$VARIANT_ID"
+)
+
+
 get_host_version_id()
 (
     # shellcheck disable=SC1091
@@ -888,9 +896,18 @@ create()
 
 
 enter()
-{
-    run true true false "$SHELL" -l
-}
+(
+    emit_escape_sequence=false
+    host_id=$(get_host_id)
+    host_variant_id=$(get_host_variant_id)
+
+    if [ "$host_id" = "fedora" ] 2>&3 \
+       && { [ "$host_variant_id" = "silverblue" ] 2>&3 || [ "$host_variant_id" = "workstation" ] 2>&3; }; then
+        emit_escape_sequence=true
+    fi
+
+    run "$emit_escape_sequence" true false "$SHELL" -l
+)
 
 
 init_container()


### PR DESCRIPTION
In practice, the OSC 777 escape sequence is only supported in Fedora's
fork of VTE. It's completely useless on other distributions.

Moreover, the user experience of tracking and preserving the user's
current toolbox container in GNOME Terminal was designed specifically
for Fedora Silverblue and Workstation, and it still has some rough
edges. eg., not being able to request a shell running on the host from
inside the toolbox, which can make the user feel trapped. While those
kinks get worked out, it's better to not expose users of other Fedora
variants, like CoreOS, to this.