### PR TITLE
Don't sanity check /etc/subgid and /etc/subuid when running as root

### DIFF
--- a/toolbox
+++ b/toolbox
@@ -1781,6 +1781,8 @@ while has_prefix "$1" -; do
     shift
 done
 
+echo "$base_toolbox_command: running as real user ID $user_id_real" >&3
+
 if ! toolbox_command_path=$(realpath "$0" 2>&3); then
     echo "$base_toolbox_command: failed to resolve absolute path to $0" >&2
     exit 1

--- a/toolbox
+++ b/toolbox
@@ -1796,13 +1796,15 @@ if [ -f /run/.containerenv ] 2>&3; then
         exit 1
     fi
 else
-    echo "$base_toolbox_command: checking if /etc/subgid and /etc/subuid have entries for user $USER" >&3
+    if [ "$user_id_real" -ne 0 ] 2>&3; then
+        echo "$base_toolbox_command: checking if /etc/subgid and /etc/subuid have entries for user $USER" >&3
 
-    if ! grep "^$USER:" /etc/subgid >/dev/null 2>&3 || ! grep "^$USER:" /etc/subuid >/dev/null 2>&3; then
-        echo "$base_toolbox_command: /etc/subgid and /etc/subuid don't have entries for user $USER" >&2
-        echo "See the podman(1), subgid(5), subuid(5) and usermod(8) manuals for more" >&2
-        echo "information." >&2
-        exit 1
+        if ! grep "^$USER:" /etc/subgid >/dev/null 2>&3 || ! grep "^$USER:" /etc/subuid >/dev/null 2>&3; then
+            echo "$base_toolbox_command: /etc/subgid and /etc/subuid don't have entries for user $USER" >&2
+            echo "See the podman(1), subgid(5), subuid(5) and usermod(8) manuals for more" >&2
+            echo "information." >&2
+            exit 1
+        fi
     fi
 
     if [ "$TOOLBOX_PATH" = "" ] 2>&3; then


### PR DESCRIPTION
The /etc/subgid and /etc/subuid files are only meant to be used when
running rootless, and hence don't have an entry for root.

https://github.com/debarshiray/toolbox/issues/267