### PR TITLE
Be forgiving of a missing /etc/profile.d/toolbox.sh in 'run'

### DIFF
--- a/toolbox
+++ b/toolbox
@@ -264,6 +264,11 @@ copy_etc_profile_d_toolbox_to_container()
         return 1
     fi
 
+    if ! [ -f "$toolbox_runtime_directory"/toolbox.sh ] 2>&3; then
+        echo "$base_toolbox_command: $toolbox_runtime_directory/toolbox.sh not found" >&2
+        return 0
+    fi
+
     echo "$base_toolbox_command: copying /etc/profile.d/toolbox.sh to container $container" >&3
 
     if ! $prefix_sudo podman exec \
@@ -283,6 +288,7 @@ copy_etc_profile_d_toolbox_to_runtime_directory()
     profile_d_lock="$toolbox_runtime_directory"/profile.d-toolbox.lock
 
     if ! [ -f /etc/profile.d/toolbox.sh ] 2>&3; then
+        echo "$base_toolbox_command: /etc/profile.d/toolbox.sh not found" >&2
         return 0
     fi
 


### PR DESCRIPTION
It's common for people to run the toolbox script straight out of the
source tree without installing it system-wide. In such cases, it's
likely that /etc/profile.d/toolbox.sh would be absent on the host, and
as a result also absent from the toolbox container.

The welcome messages and the primary shell prompt (or PS1) are set
through /etc/profile.d/toolbox.sh, so not having it does degrade the
user experience, but it's probably not severe enough to fail the 'run'
command.

This should have been part of commit 0db54946b43e040 which split the
copying of /etc/profile.d/toolbox.sh into a container into two steps to
avoid using 'podman cp'. It already tried to handle the missing file
in the first step, but not in the second step.

It's also nice to at least make the user aware of the situation by
printing an error message.